### PR TITLE
Stop the WSConn :not_connected retry storm in NodeProxy

### DIFF
--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -248,8 +248,35 @@ defmodule RemoteChain.NodeProxy do
       )
 
       GenServer.reply(from, {:error, :disconnect})
-      # Connection is dead (e.g. WSConn exited before handle_connect or crashed).
-      # Remove it so we don't keep picking it and hitting Globals.await timeouts.
+      handle_failed_send(state, conn)
+    end
+  end
+
+  # Decide what to do with a connection after a failed send.
+  #
+  # `WSConn.send_request/3` returns `{:error, :not_connected}` in two very
+  # different situations:
+  #
+  #   1. The WSConn process is dead (crashed, exited before `handle_connect`).
+  #   2. The WSConn process is still alive but its async handshake has not
+  #      completed yet (slow TCP/TLS, slow DNS, the first 500ms after
+  #      `WSConn.start/3`).
+  #
+  # If we treat (2) as (1) and eagerly evict the conn, the next request will
+  # spawn a brand new WSConn that is also mid-handshake, and the warning
+  # `Failed to send request ... :not_connected` keeps repeating instead of
+  # healing as soon as the in-flight handshake completes.
+  #
+  # We only evict (and trigger `ensure_connections`) when the WSConn pid is
+  # really dead. If it is still alive we keep it in the pool; either its
+  # handshake completes on its own, or its own ping watchdog
+  # (`WSConn.handle_info(:ping, _)`) tears it down and the existing
+  # `:DOWN` monitor in `NodeProxy` cleans the pool up.
+  @doc false
+  def handle_failed_send(state, conn) do
+    if Process.alive?(conn) do
+      state
+    else
       state = remove_connection(state, conn)
       pid = self()
 

--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -62,10 +62,41 @@ defmodule RemoteChain.NodeProxy do
   @impl true
   def handle_call({:rpc, method, params}, from, state) do
     state = ensure_connections(state)
-    conn = Enum.random(Map.values(state.connections))
+    conn = pick_connection(state.connections)
     id = state.req + 1
     state = send_request(state, conn, id, method, params, from)
     {:noreply, %{state | req: id}}
+  end
+
+  # Prefer a WSConn whose async handshake has already completed.
+  #
+  # `RemoteChain.WSConn.send_request/3` blocks for up to 500&nbsp;ms in
+  # `Globals.await({WSConn, pid}, 500)` waiting for `handle_connect/2` to
+  # publish the underlying connection. While the handshake is in flight
+  # there is no point routing a request through that pid: the call will
+  # just time out, log
+  #
+  #     Failed to send request to #PID<...>: ... {:error, :not_connected}
+  #     Awaiting undefined key: {RemoteChain.WSConn, #PID<...>}
+  #
+  # and bubble `{:error, :disconnect}` back to `RPCCache.rpc!/3`. If
+  # several WSConns happen to be handshaking simultaneously (e.g. right
+  # after a fallback was added or after a slow upstream rejected the
+  # previous conn) every random pick fails for ~500&nbsp;ms and the
+  # warning keeps repeating without healing.
+  #
+  # Filter the pool to the connections that have completed their
+  # handshake. Only fall back to the full pool when none are ready, so
+  # the empty-pool behaviour (a crash, since there is nothing we can do)
+  # is preserved.
+  @doc false
+  def pick_connection(connections) do
+    pids = Map.values(connections)
+
+    case Enum.filter(pids, &RemoteChain.WSConn.ready?/1) do
+      [] -> Enum.random(pids)
+      ready -> Enum.random(ready)
+    end
   end
 
   @impl true

--- a/lib/remote_chain/ws_conn.ex
+++ b/lib/remote_chain/ws_conn.ex
@@ -141,6 +141,20 @@ defmodule RemoteChain.WSConn do
     end
   end
 
+  @doc """
+  Non-blocking readiness check. Returns true iff `handle_connect/2` has
+  already populated `Globals` with this WSConn's underlying connection
+  (i.e. the TCP/TLS/WS handshake is done).
+
+  Unlike `send_request/3`, this never blocks and never registers a waiter
+  in `Globals`, so callers can use it to filter the connection pool
+  without paying the 500&nbsp;ms `Globals.await` budget or producing
+  noisy "Awaiting undefined key" / zombie-timeout log lines.
+  """
+  def ready?(pid) when is_pid(pid) do
+    Globals.get({__MODULE__, pid}) != nil
+  end
+
   @impl true
   def handle_info(
         :ping,

--- a/test/remote_chain/node_proxy_test.exs
+++ b/test/remote_chain/node_proxy_test.exs
@@ -1,0 +1,132 @@
+# Diode Server
+# Copyright 2021-2024 Diode
+# Licensed under the Diode License, Version 1.1
+defmodule RemoteChain.NodeProxyTest do
+  @moduledoc """
+  Regression tests for the `:not_connected` retry storm described in
+  `lib/remote_chain/node_proxy.ex`.
+
+  Background:
+
+  When `RemoteChain.WSConn.send_request/3` fails to deliver the frame it
+  returns `{:error, :not_connected}`. This can happen for two distinct
+  reasons:
+
+    1. The WSConn process is dead (crashed, exited before `handle_connect`
+       fired, etc.).
+    2. The WSConn process is still alive but its async handshake (TCP +
+       TLS + WebSocket upgrade) has not completed within the 500 ms
+       `Globals.await` budget yet.
+
+  Until this fix `RemoteChain.NodeProxy.send_request/6` always treated
+  every failed send as case (1) and evicted the connection, then asked
+  `ensure_connections` to spawn a fresh WSConn. Under case (2) that fresh
+  WSConn is *also* mid-handshake, so the next request hits the same
+  `:not_connected` -> evict -> respawn loop and the warning
+
+      Failed to send request to #PID<...>: ... {:error, :not_connected}
+
+  followed by
+
+      ** (RuntimeError) RPC error in ChainImpl.eth_getBlockByNumber(...): {:error, :disconnect}
+
+  keeps repeating instead of healing once the in-flight handshake
+  finishes.
+  """
+  use ExUnit.Case, async: false
+  alias RemoteChain.NodeProxy
+
+  describe "handle_failed_send/2" do
+    test "keeps a still-handshaking (alive) WSConn in the pool" do
+      # Simulate a WSConn that is doing its async handshake: the process
+      # is alive but never registered itself in `Globals`, so
+      # `WSConn.send_request/3` times out and returns
+      # `{:error, :not_connected}`.
+      conn =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert Process.alive?(conn)
+
+      state = %NodeProxy{
+        chain: Chains.Anvil,
+        connections: %{"ws://localhost:28822" => conn},
+        fallback: nil,
+        fallback_url: nil,
+        requests: %{}
+      }
+
+      new_state = NodeProxy.handle_failed_send(state, conn)
+
+      # The connection MUST still be in the pool, otherwise the next
+      # request will trigger `ensure_connections` to spawn yet another
+      # mid-handshake WSConn, perpetuating the `:not_connected` storm.
+      assert new_state.connections == state.connections,
+             "alive (still handshaking) WSConn must not be evicted"
+
+      send(conn, :stop)
+    end
+
+    test "evicts a dead WSConn and replies to its in-flight requests" do
+      # Simulate a WSConn that has actually crashed.
+      conn = spawn(fn -> :ok end)
+      ref = Process.monitor(conn)
+      assert_receive {:DOWN, ^ref, :process, ^conn, _}, 1_000
+      refute Process.alive?(conn)
+
+      from = {self(), make_ref()}
+
+      state = %NodeProxy{
+        chain: Chains.Anvil,
+        connections: %{"ws://localhost:28822" => conn},
+        fallback: nil,
+        fallback_url: nil,
+        requests: %{
+          42 => %{
+            from: from,
+            method: "eth_blockNumber",
+            params: [],
+            start_ms: System.os_time(:millisecond),
+            conn: conn
+          }
+        }
+      }
+
+      new_state = NodeProxy.handle_failed_send(state, conn)
+
+      assert new_state.connections == %{},
+             "dead WSConn must be removed from the pool"
+
+      assert new_state.requests == %{},
+             "in-flight requests on the dead WSConn must be cleared"
+
+      # `remove_connection/2` should have replied to the orphaned caller
+      # with `{:error, :disconnect}`.
+      from_ref = elem(from, 1)
+      assert_receive {^from_ref, {:error, :disconnect}}, 1_000
+    end
+
+    test "evicts a dead fallback WSConn and resets fallback_url" do
+      conn = spawn(fn -> :ok end)
+      ref = Process.monitor(conn)
+      assert_receive {:DOWN, ^ref, :process, ^conn, _}, 1_000
+      refute Process.alive?(conn)
+
+      state = %NodeProxy{
+        chain: Chains.Anvil,
+        connections: %{},
+        fallback: conn,
+        fallback_url: "ws://fallback.example/",
+        requests: %{}
+      }
+
+      new_state = NodeProxy.handle_failed_send(state, conn)
+
+      assert new_state.fallback == nil
+      assert new_state.fallback_url == nil
+    end
+  end
+end

--- a/test/remote_chain/node_proxy_test.exs
+++ b/test/remote_chain/node_proxy_test.exs
@@ -129,4 +129,126 @@ defmodule RemoteChain.NodeProxyTest do
       assert new_state.fallback_url == nil
     end
   end
+
+  # Second symptom of the same root cause:
+  #
+  #     00:15:45.880 [warning] Failed to send request to #PID<0.109448870.0>: ... {:error, :not_connected}
+  #     00:15:45.881 [info] Awaiting undefined key: {RemoteChain.WSConn, #PID<0.109449407.0>}
+  #     ** (RuntimeError) RPC error in Chains.Moonbeam.eth_getBlockByNumber(...): {:error, :disconnect}
+  #
+  # Two distinct WSConn pids in two consecutive log lines: one had
+  # `send_request/3` time out, then `RPCCache`'s retry picked a *second*
+  # still-handshaking WSConn from the pool and timed out again.
+  #
+  # `NodeProxy.handle_call({:rpc, ...})` used to pick blindly with
+  # `Enum.random(Map.values(state.connections))`, so when several
+  # WSConns were handshaking simultaneously every random pick paid the
+  # full 500 ms `Globals.await` budget and failed. The fix is
+  # `pick_connection/1`, which prefers WSConns whose handshake has
+  # already completed (`WSConn.ready?/1`).
+  describe "pick_connection/1 (regression: avoid still-handshaking conns)" do
+    test "prefers ready WSConns over still-handshaking ones" do
+      ready_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      handshaking_pid =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      # Mark `ready_pid` as ready by mimicking what `WSConn.handle_connect/2`
+      # does: publish the underlying connection in `Globals` under
+      # `{WSConn, pid}`. The actual value is opaque to the readiness check.
+      Globals.put({RemoteChain.WSConn, ready_pid}, :fake_conn)
+
+      try do
+        assert RemoteChain.WSConn.ready?(ready_pid)
+        refute RemoteChain.WSConn.ready?(handshaking_pid)
+
+        connections = %{
+          "ws://ready/" => ready_pid,
+          "ws://handshaking/" => handshaking_pid
+        }
+
+        # Run many picks. Without the fix this is uniform random over
+        # the two pids, so on a 2-conn pool the handshaking pid would be
+        # chosen ~50% of the time. With the fix it must be picked 0% of
+        # the time as long as a ready peer exists.
+        for _ <- 1..200 do
+          assert NodeProxy.pick_connection(connections) == ready_pid,
+                 "must never route to a still-handshaking WSConn while a ready one is available"
+        end
+      after
+        Globals.pop({RemoteChain.WSConn, ready_pid})
+        send(ready_pid, :stop)
+        send(handshaking_pid, :stop)
+      end
+    end
+
+    test "falls back to the full pool when no WSConn is ready yet" do
+      # Right after start-up (or after both conns were just respawned)
+      # every pid in the pool is handshaking. We must still attempt the
+      # request -- not crash on an empty list -- so callers get a
+      # well-defined `{:error, :disconnect}` rather than a process exit.
+      pid_a = spawn(fn -> receive do: (:stop -> :ok) end)
+      pid_b = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      try do
+        refute RemoteChain.WSConn.ready?(pid_a)
+        refute RemoteChain.WSConn.ready?(pid_b)
+
+        connections = %{"ws://a/" => pid_a, "ws://b/" => pid_b}
+
+        seen =
+          for _ <- 1..200, into: MapSet.new() do
+            NodeProxy.pick_connection(connections)
+          end
+
+        assert MapSet.subset?(seen, MapSet.new([pid_a, pid_b]))
+        assert MapSet.size(seen) >= 1
+      after
+        send(pid_a, :stop)
+        send(pid_b, :stop)
+      end
+    end
+  end
+
+  describe "WSConn.ready?/1" do
+    test "returns false for an alive but non-registered (still handshaking) pid" do
+      pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      try do
+        refute RemoteChain.WSConn.ready?(pid),
+               "a WSConn that has not run handle_connect/2 yet must not be reported ready"
+
+        # Crucially, calling `ready?/1` must NOT register a waiter in
+        # `Globals` -- otherwise the caller would either block or leave
+        # a zombie waiting entry that later fires
+        # `Logger.error("Timeout waiting for {RemoteChain.WSConn, ...}")`.
+        # We verify that by asserting the pid is still not "ready" and
+        # that no `:update` message landed in our mailbox from the call.
+        refute_receive {:update, {RemoteChain.WSConn, ^pid}, _}, 50
+      after
+        send(pid, :stop)
+      end
+    end
+
+    test "returns true once handle_connect/2 has registered the conn" do
+      pid = spawn(fn -> receive do: (:stop -> :ok) end)
+      Globals.put({RemoteChain.WSConn, pid}, :fake_conn)
+
+      try do
+        assert RemoteChain.WSConn.ready?(pid)
+      after
+        Globals.pop({RemoteChain.WSConn, pid})
+        send(pid, :stop)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes two related symptoms with the same root cause: a WSConn whose async TCP/TLS/WS handshake hasn't completed yet returns `{:error, :not_connected}` from `RemoteChain.WSConn.send_request/3`, and `NodeProxy` reacts to that as if the connection were dead, perpetuating the failure instead of letting the in-flight handshake finish.

## Symptoms

### Symptom 1 — re-spawn storm

```
08:12:10.014 [warning] Failed to send request to #PID<0.13670260.0>: "...eth_getBlockByNumber...": {:error, :not_connected}
08:12:10.015 [error] Process #PID<0.13669863.0> on node :diode_node@localhost raised an exception
** (RuntimeError) RPC error in Chains.Moonbeam.eth_getBlockByNumber([15307943, false]): {:error, :disconnect}
    (diode 0.0.0) lib/remote_chain/rpc_cache.ex:311: RemoteChain.RPCCache.rpc!/3
```

### Symptom 2 — request-routing churn

```
00:15:45.880 [warning] Failed to send request to #PID<0.109448870.0>: "...eth_getBlockByNumber...": {:error, :not_connected}
00:15:45.881 [info]    Awaiting undefined key: {RemoteChain.WSConn, #PID<0.109449407.0>}
00:15:45.884 [error]   ** (RuntimeError) RPC error in Chains.Moonbeam.eth_getBlockByNumber([15307932, false]): {:error, :disconnect}
                       (diode 0.0.0) lib/remote_chain/rpc_cache.ex:311: RemoteChain.RPCCache.rpc!/3
```

Two distinct WSConn pids in two consecutive log lines: one had `WSConn.send_request/3` time out, then `RPCCache.rpc/3`'s retry picked a *second* still-handshaking WSConn from the pool and timed out again.

In both cases the messages keep repeating without healing.

## Root cause

`RemoteChain.WSConn.send_request/3` returns `{:error, :not_connected}` in two distinct situations:

1. The WSConn process is dead (crashed, exited before `handle_connect`).
2. The WSConn process is **still alive** but its async handshake (TCP + TLS + WebSocket upgrade) has not completed within the 500&nbsp;ms `Globals.await({WSConn, pid}, 500)` budget. This is normal during the first few hundred ms after `WSConn.start/3`, or any time the upstream RPC node is slow to accept the connection.

Two pieces of `NodeProxy` conflated case (2) with case (1):

- **`NodeProxy.send_request/6`** treated every failed send as a dead connection: replied `{:error, :disconnect}`, evicted the conn, and asked `ensure_connections` to spawn a fresh WSConn. The fresh WSConn was also mid-handshake → next request hits the same path → loop never heals.

- **`NodeProxy.handle_call({:rpc, ...})`** picked a connection blindly with `Enum.random(Map.values(state.connections))`, with no readiness filter. When the pool contained any still-handshaking conns (right after start-up, after a fallback was added, after a slow upstream rejected the previous conn) every random pick paid the full 500&nbsp;ms `Globals.await` budget and failed.

## Fix

Two complementary changes — both in this PR — that target the same root cause:

1. **`NodeProxy.handle_failed_send/2`** (commit 1) — only evict (and re-arm `ensure_connections`) when the WSConn pid is actually `Process.alive?(false)`. If it's still alive, leave it in the pool: either its handshake completes on its own and subsequent requests succeed, or its own ping watchdog (`WSConn.handle_info(:ping, _)`) tears it down and the existing `:DOWN` monitor in `NodeProxy` cleans the pool up.

2. **`NodeProxy.pick_connection/1`** (commit 2) — prefer WSConns whose handshake has already completed. Falls back to the full pool only when none are ready, preserving the empty-pool behaviour so callers still see a well-defined `{:error, :disconnect}` rather than a silent hang.

   This relies on a new helper, **`RemoteChain.WSConn.ready?/1`**, a non-blocking, side-effect-free check based on `Globals.get({WSConn, pid})`. Unlike `WSConn.send_request/3` it does **not** register a waiter in `Globals`, so it produces no "Awaiting undefined key" or zombie-timeout log noise even when called for many handshaking pids.

Both decisions are extracted to public helpers (`@doc false`) so they can be unit-tested without standing up real websockets.

## Tests

`test/remote_chain/node_proxy_test.exs` covers seven cases across three groups:

`describe "handle_failed_send/2"`:
- alive (still handshaking) WSConn — must be **kept** in the pool (regression test for symptom 1)
- dead WSConn — must be removed and its in-flight callers replied to with `{:error, :disconnect}`
- dead fallback WSConn — must clear both `fallback` and `fallback_url`

`describe "pick_connection/1"`:
- prefers ready WSConns over still-handshaking ones (regression test for symptom 2; runs 200 picks and asserts the handshaking pid is **never** chosen while a ready peer exists)
- falls back to the full pool when no WSConn is ready yet

`describe "WSConn.ready?/1"`:
- returns `false` for an alive but non-registered (still handshaking) pid, with a `refute_receive` proving the call does **not** register a `Globals` waiter
- returns `true` once `handle_connect/2` has registered the conn

Verified all four "new" tests fail on a tree with the test file but without the lib changes (`UndefinedFunctionError` for `WSConn.ready?/1` / `NodeProxy.handle_failed_send/2`), and pass with the fix:

```
$ DIODE_MINIMAL_TEST=1 MIX_ENV=test mix test --no-start test/remote_chain/node_proxy_test.exs
7 tests, 0 failures
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dc65db9-ef9c-4187-89b0-d4a414fd52e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dc65db9-ef9c-4187-89b0-d4a414fd52e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

