### PR TITLE
feat(snap): automatic wallet backup on snap removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ sudo snap stop diode-node
 sudo snap save diode-node
 ```
 
-When you remove the snap (`sudo snap remove diode-node`), the remove hook automatically archives critical node files (identity, Erlang DNS config, and wallet database) to `/var/backups/diode-node/diode_node_backup_<timestamp>.tar.gz`. The `backup-dir` system-files plug must be connected for this path to work; otherwise rely on `snap saved` within 31 days.
+When you remove the snap (`sudo snap remove diode-node`), the remove hook automatically archives critical node files (identity and wallet database) to `/var/backups/diode-node/diode_node_backup_<timestamp>.tar.gz`. The `backup-dir` system-files plug must be connected for this path to work; otherwise rely on `snap saved` within 31 days.
 
 To restore from an automatic backup after reinstalling:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ To restore from an automatic backup after reinstalling:
 
 ```bash
 sudo snap install diode-node
+sudo snap connect diode-node:backup-dir
 sudo snap stop diode-node.service
 sudo snap run --shell diode-node -c 'bin/restore_snap_backup /var/backups/diode-node/diode_node_backup_YYYY-MM-DD_HHMMSS.tar.gz'
 sudo snap start diode-node.service

--- a/README.md
+++ b/README.md
@@ -112,6 +112,27 @@ sudo sysctl --system
 
 # Operations
 
+## Backup and restore
+
+Before planned maintenance, flush caches and create a snap snapshot:
+
+```bash
+sudo diode-node.flush
+sudo snap stop diode-node
+sudo snap save diode-node
+```
+
+When you remove the snap (`sudo snap remove diode-node`), the remove hook automatically archives critical node files (identity, Erlang DNS config, and wallet database) to `/var/backups/diode-node/diode_node_backup_<timestamp>.tar.gz`. The `backup-dir` system-files plug must be connected for this path to work; otherwise rely on `snap saved` within 31 days.
+
+To restore from an automatic backup after reinstalling:
+
+```bash
+sudo snap install diode-node
+sudo snap stop diode-node.service
+sudo snap run --shell diode-node -c 'bin/restore_snap_backup /var/backups/diode-node/diode_node_backup_YYYY-MM-DD_HHMMSS.tar.gz'
+sudo snap start diode-node.service
+```
+
 ## See last service restart reason
 
 When running the snap installation then it's a two step process to see the last service restart reason:

--- a/scripts/restore_snap_backup.sh
+++ b/scripts/restore_snap_backup.sh
@@ -10,8 +10,9 @@ Restores node identity and wallet data from an automatic snap-removal backup.
 Run after reinstalling diode-node and stopping the service:
 
   sudo snap install diode-node
+  sudo snap connect diode-node:backup-dir
   sudo snap stop diode-node.service
-  sudo $0 /var/backups/diode-node/diode_node_backup_YYYY-MM-DD_HHMMSS.tar.gz
+  sudo snap run --shell diode-node -c 'bin/restore_snap_backup /var/backups/diode-node/diode_node_backup_YYYY-MM-DD_HHMMSS.tar.gz'
   sudo snap start diode-node.service
 EOF
 }
@@ -29,11 +30,13 @@ if [[ ! -f "$backup_file" ]]; then
 fi
 
 if [[ -z "${SNAP:-}" || -z "${SNAP_DATA:-}" || -z "${SNAP_USER_DATA:-}" ]]; then
-	echo "Run this script inside the diode-node snap environment (e.g. sudo diode-node.shell)." >&2
-	echo "Or set SNAP, SNAP_DATA, and SNAP_USER_DATA manually." >&2
+	echo "Run inside the diode-node snap (connect backup-dir first):" >&2
+	echo "  sudo snap connect diode-node:backup-dir" >&2
+	echo "  sudo snap run --shell diode-node -c 'bin/restore_snap_backup <backup.tar.gz>'" >&2
 	exit 1
 fi
 
+umask 077
 staging_dir=$(mktemp -d)
 trap 'rm -rf "$staging_dir"' EXIT
 

--- a/scripts/restore_snap_backup.sh
+++ b/scripts/restore_snap_backup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Restore a diode-node backup created by the snap remove hook.
+set -euo pipefail
+
+usage() {
+	cat <<EOF
+Usage: $0 <backup.tar.gz>
+
+Restores node identity and wallet data from an automatic snap-removal backup.
+Run after reinstalling diode-node and stopping the service:
+
+  sudo snap install diode-node
+  sudo snap stop diode-node.service
+  sudo $0 /var/backups/diode-node/diode_node_backup_YYYY-MM-DD_HHMMSS.tar.gz
+  sudo snap start diode-node.service
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+	usage
+	exit 1
+fi
+
+backup_file="$1"
+
+if [[ ! -f "$backup_file" ]]; then
+	echo "Backup file not found: $backup_file" >&2
+	exit 1
+fi
+
+if [[ -z "${SNAP:-}" || -z "${SNAP_DATA:-}" || -z "${SNAP_USER_DATA:-}" ]]; then
+	echo "Run this script inside the diode-node snap environment (e.g. sudo diode-node.shell)." >&2
+	echo "Or set SNAP, SNAP_DATA, and SNAP_USER_DATA manually." >&2
+	exit 1
+fi
+
+staging_dir=$(mktemp -d)
+trap 'rm -rf "$staging_dir"' EXIT
+
+tar -xzf "$backup_file" -C "$staging_dir"
+
+if [[ -d "$staging_dir/snap_user_data" ]]; then
+	mkdir -p "$SNAP_USER_DATA"
+	cp -a "$staging_dir/snap_user_data/." "$SNAP_USER_DATA/"
+fi
+
+if [[ -d "$staging_dir/snap_data" ]]; then
+	mkdir -p "$SNAP_DATA"
+	cp -a "$staging_dir/snap_data/." "$SNAP_DATA/"
+fi
+
+echo "Restored backup into $SNAP_DATA and $SNAP_USER_DATA"

--- a/scripts/snap_backup_on_remove.sh
+++ b/scripts/snap_backup_on_remove.sh
@@ -23,12 +23,6 @@ stage_critical_files() {
 		has_data=1
 	fi
 
-	if [[ -f "$snap_user_data/erl_inetrc" ]]; then
-		mkdir -p "$staging_dir/snap_user_data"
-		cp "$snap_user_data/erl_inetrc" "$staging_dir/snap_user_data/"
-		has_data=1
-	fi
-
 	if [[ -d "$snap_data" ]]; then
 		for nodedata in "$snap_data"/nodedata_*; do
 			if [[ -d "$nodedata" ]]; then

--- a/scripts/snap_backup_on_remove.sh
+++ b/scripts/snap_backup_on_remove.sh
@@ -54,12 +54,14 @@ snap: ${SNAP_NAME}
 snap_data: ${snap_data}
 snap_user_data: ${snap_user_data}
 
-Restore with scripts/restore_snap_backup.sh after reinstalling the snap.
+Restore with bin/restore_snap_backup after reinstalling the snap
+(connect backup-dir: sudo snap connect diode-node:backup-dir).
 If this backup is missing, use "snap saved" within 31 days of removal.
 EOF
 }
 
 main() {
+	umask 077
 	local snap_data="${SNAP_DATA:-}"
 	local snap_user_data="${SNAP_USER_DATA:-}"
 
@@ -86,6 +88,7 @@ main() {
 		log "use 'snap saved' within 31 days to recover data via 'snap restore'"
 		exit 0
 	fi
+	chmod 0700 "$BACKUP_DIR" 2>/dev/null || true
 
 	local timestamp backup_file
 	timestamp=$(date -u +%Y-%m-%d_%H%M%S)
@@ -97,7 +100,6 @@ main() {
 	fi
 
 	chmod 0600 "$backup_file"
-	chmod 0700 "$BACKUP_DIR" 2>/dev/null || true
 
 	log "wallet backup saved to $backup_file"
 }

--- a/scripts/snap_backup_on_remove.sh
+++ b/scripts/snap_backup_on_remove.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Automatic wallet backup when the diode-node snap is removed.
+# Invoked from snap/hooks/remove; BACKUP_DIR can be overridden for tests.
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/diode-node}"
+SNAP_NAME="${SNAP_NAME:-diode-node}"
+staging_dir=""
+
+log() {
+	echo "diode-node remove hook: $*" >&2
+}
+
+stage_critical_files() {
+	local snap_data="$1"
+	local snap_user_data="$2"
+	local staging_dir="$3"
+	local has_data=0
+
+	if [[ -f "$snap_user_data/node" ]]; then
+		mkdir -p "$staging_dir/snap_user_data"
+		cp "$snap_user_data/node" "$staging_dir/snap_user_data/"
+		has_data=1
+	fi
+
+	if [[ -f "$snap_user_data/erl_inetrc" ]]; then
+		mkdir -p "$staging_dir/snap_user_data"
+		cp "$snap_user_data/erl_inetrc" "$staging_dir/snap_user_data/"
+		has_data=1
+	fi
+
+	if [[ -d "$snap_data" ]]; then
+		for nodedata in "$snap_data"/nodedata_*; do
+			if [[ -d "$nodedata" ]]; then
+				mkdir -p "$staging_dir/snap_data"
+				cp -a "$nodedata" "$staging_dir/snap_data/"
+				has_data=1
+			fi
+		done
+	fi
+
+	echo "$has_data"
+}
+
+write_manifest() {
+	local staging_dir="$1"
+	local snap_data="$2"
+	local snap_user_data="$3"
+
+	cat >"$staging_dir/manifest.txt" <<EOF
+diode-node automatic backup
+created: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+snap: ${SNAP_NAME}
+snap_data: ${snap_data}
+snap_user_data: ${snap_user_data}
+
+Restore with scripts/restore_snap_backup.sh after reinstalling the snap.
+If this backup is missing, use "snap saved" within 31 days of removal.
+EOF
+}
+
+main() {
+	local snap_data="${SNAP_DATA:-}"
+	local snap_user_data="${SNAP_USER_DATA:-}"
+
+	if [[ -z "$snap_data" || -z "$snap_user_data" ]]; then
+		log "SNAP_DATA or SNAP_USER_DATA not set, skipping backup"
+		exit 0
+	fi
+
+	staging_dir=$(mktemp -d)
+	trap '[[ -n "$staging_dir" ]] && rm -rf "$staging_dir"' EXIT
+
+	local has_data
+	has_data=$(stage_critical_files "$snap_data" "$snap_user_data" "$staging_dir")
+
+	if [[ "$has_data" -eq 0 ]]; then
+		log "no critical node data found, skipping backup"
+		exit 0
+	fi
+
+	write_manifest "$staging_dir" "$snap_data" "$snap_user_data"
+
+	if ! mkdir -p "$BACKUP_DIR" 2>/dev/null; then
+		log "cannot create backup directory $BACKUP_DIR (is backup-dir plug connected?)"
+		log "use 'snap saved' within 31 days to recover data via 'snap restore'"
+		exit 0
+	fi
+
+	local timestamp backup_file
+	timestamp=$(date -u +%Y-%m-%d_%H%M%S)
+	backup_file="$BACKUP_DIR/diode_node_backup_${timestamp}.tar.gz"
+
+	if ! tar -czf "$backup_file" -C "$staging_dir" .; then
+		log "failed to write backup archive to $backup_file"
+		exit 0
+	fi
+
+	chmod 0600 "$backup_file"
+	chmod 0700 "$BACKUP_DIR" 2>/dev/null || true
+
+	log "wallet backup saved to $backup_file"
+}
+
+main "$@"

--- a/snap/Makefile
+++ b/snap/Makefile
@@ -8,6 +8,12 @@ install:
 	mkdir -p $(DESTDIR)/meta/hooks
 	cp snap/configure $(DESTDIR)/meta/hooks/
 	chmod +x $(DESTDIR)/meta/hooks/configure
+	cp snap/hooks/remove $(DESTDIR)/meta/hooks/remove
+	chmod +x $(DESTDIR)/meta/hooks/remove
 	tar -x --no-same-owner -zf _build/prod/diode_node-`./scripts/version.sh`.tar.gz -C $(DESTDIR)
 	cp snap/run $(DESTDIR)/bin/
 	chmod +x $(DESTDIR)/bin/run
+	cp scripts/snap_backup_on_remove.sh $(DESTDIR)/bin/backup_on_remove
+	chmod +x $(DESTDIR)/bin/backup_on_remove
+	cp scripts/restore_snap_backup.sh $(DESTDIR)/bin/restore_snap_backup
+	chmod +x $(DESTDIR)/bin/restore_snap_backup

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Runs before snap data is deleted. See scripts/snap_backup_on_remove.sh.
+exec "$SNAP/bin/backup_on_remove"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,7 +87,7 @@ apps:
 
   shell:
     command: bin/run elevated remote
-    plugs: [network, network-bind]
+    plugs: [network, network-bind, backup-dir]
 
   rpc:
     command: bin/run elevated rpc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,16 @@ lint:
     - metadata:
         - donation
 
+plugs:
+  backup-dir:
+    interface: system-files
+    write:
+      - /var/backups/diode-node
+
+hooks:
+  remove:
+    plugs: [backup-dir]
+
 parts:
   diode-node:
     # See 'snapcraft plugins'

--- a/test/snap_backup_on_remove_test.exs
+++ b/test/snap_backup_on_remove_test.exs
@@ -53,6 +53,7 @@ defmodule SnapBackupOnRemoveTest do
 
     backup_path = Path.join(context.backup_dir, backup_name)
     assert File.stat!(backup_path).mode &&& 0o777 == 0o600
+    assert File.stat!(context.backup_dir).mode &&& 0o777 == 0o700
 
     File.mkdir_p!(context.extract_dir)
 

--- a/test/snap_backup_on_remove_test.exs
+++ b/test/snap_backup_on_remove_test.exs
@@ -32,17 +32,11 @@ defmodule SnapBackupOnRemoveTest do
     System.cmd("bash", [@script], env: env, stderr_to_stdout: true)
   end
 
-  test "creates tarball with node identity, erl_inetrc, and nodedata", context do
+  test "creates tarball with node identity and nodedata", context do
     File.mkdir_p!(Path.join(context.snap_data, "nodedata_prod"))
     File.mkdir_p!(context.snap_user_data)
 
     File.write!(Path.join(context.snap_user_data, "node"), "diode_node@host.diode\n")
-
-    File.write!(
-      Path.join(context.snap_user_data, "erl_inetrc"),
-      "{host, {127,0,0,1}, [\"host.diode\", \"diode_node@host.diode\"]}.\n"
-    )
-
     File.write!(Path.join(context.snap_data, "nodedata_prod/wallet.dat"), "wallet-secrets")
 
     {output, 0} = run_backup(context)
@@ -63,15 +57,38 @@ defmodule SnapBackupOnRemoveTest do
     assert File.read!(Path.join(context.extract_dir, "snap_user_data/node")) ==
              "diode_node@host.diode\n"
 
-    assert File.read!(Path.join(context.extract_dir, "snap_user_data/erl_inetrc")) =~
-             "{host, {127,0,0,1}"
-
     assert File.read!(Path.join(context.extract_dir, "snap_data/nodedata_prod/wallet.dat")) ==
              "wallet-secrets"
 
     manifest = File.read!(Path.join(context.extract_dir, "manifest.txt"))
     assert manifest =~ "diode-node automatic backup"
     assert manifest =~ context.snap_data
+  end
+
+  test "does not backup erl_inetrc even when present", context do
+    File.mkdir_p!(Path.join(context.snap_data, "nodedata_prod"))
+    File.mkdir_p!(context.snap_user_data)
+
+    File.write!(Path.join(context.snap_user_data, "node"), "diode_node@host.diode\n")
+
+    File.write!(
+      Path.join(context.snap_user_data, "erl_inetrc"),
+      "{host, {127,0,0,1}, [\"host.diode\", \"diode_node@host.diode\"]}.\n"
+    )
+
+    File.write!(Path.join(context.snap_data, "nodedata_prod/wallet.dat"), "wallet-secrets")
+
+    {output, 0} = run_backup(context)
+    assert output =~ "wallet backup saved"
+
+    [backup_name] = File.ls!(context.backup_dir)
+    backup_path = Path.join(context.backup_dir, backup_name)
+    File.mkdir_p!(context.extract_dir)
+
+    {_, 0} =
+      System.cmd("tar", ["-xzf", backup_path, "-C", context.extract_dir], stderr_to_stdout: true)
+
+    refute File.exists?(Path.join(context.extract_dir, "snap_user_data/erl_inetrc"))
   end
 
   test "skips backup when no critical data exists", context do

--- a/test/snap_backup_on_remove_test.exs
+++ b/test/snap_backup_on_remove_test.exs
@@ -1,0 +1,102 @@
+defmodule SnapBackupOnRemoveTest do
+  use ExUnit.Case, async: true
+
+  @script Path.expand("../scripts/snap_backup_on_remove.sh", __DIR__)
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "snap_backup_test_#{System.unique_integer([:positive])}")
+    snap_data = Path.join(root, "snap_data")
+    snap_user_data = Path.join(root, "snap_user_data")
+    backup_dir = Path.join(root, "backups")
+    extract_dir = Path.join(root, "extract")
+
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    %{
+      root: root,
+      snap_data: snap_data,
+      snap_user_data: snap_user_data,
+      backup_dir: backup_dir,
+      extract_dir: extract_dir
+    }
+  end
+
+  defp run_backup(context) do
+    env = [
+      {"SNAP_DATA", context.snap_data},
+      {"SNAP_USER_DATA", context.snap_user_data},
+      {"SNAP_NAME", "diode-node"},
+      {"BACKUP_DIR", context.backup_dir}
+    ]
+
+    System.cmd("bash", [@script], env: env, stderr_to_stdout: true)
+  end
+
+  test "creates tarball with node identity, erl_inetrc, and nodedata", context do
+    File.mkdir_p!(Path.join(context.snap_data, "nodedata_prod"))
+    File.mkdir_p!(context.snap_user_data)
+
+    File.write!(Path.join(context.snap_user_data, "node"), "diode_node@host.diode\n")
+
+    File.write!(
+      Path.join(context.snap_user_data, "erl_inetrc"),
+      "{host, {127,0,0,1}, [\"host.diode\", \"diode_node@host.diode\"]}.\n"
+    )
+
+    File.write!(Path.join(context.snap_data, "nodedata_prod/wallet.dat"), "wallet-secrets")
+
+    {output, 0} = run_backup(context)
+    assert output =~ "wallet backup saved"
+
+    [backup_name] = File.ls!(context.backup_dir)
+    assert backup_name =~ ~r/^diode_node_backup_.*\.tar\.gz$/
+
+    backup_path = Path.join(context.backup_dir, backup_name)
+    assert File.stat!(backup_path).mode &&& 0o777 == 0o600
+
+    File.mkdir_p!(context.extract_dir)
+
+    {_, 0} =
+      System.cmd("tar", ["-xzf", backup_path, "-C", context.extract_dir], stderr_to_stdout: true)
+
+    assert File.read!(Path.join(context.extract_dir, "snap_user_data/node")) ==
+             "diode_node@host.diode\n"
+
+    assert File.read!(Path.join(context.extract_dir, "snap_user_data/erl_inetrc")) =~
+             "{host, {127,0,0,1}"
+
+    assert File.read!(Path.join(context.extract_dir, "snap_data/nodedata_prod/wallet.dat")) ==
+             "wallet-secrets"
+
+    manifest = File.read!(Path.join(context.extract_dir, "manifest.txt"))
+    assert manifest =~ "diode-node automatic backup"
+    assert manifest =~ context.snap_data
+  end
+
+  test "skips backup when no critical data exists", context do
+    File.mkdir_p!(context.snap_data)
+    File.mkdir_p!(context.snap_user_data)
+
+    {output, 0} = run_backup(context)
+    assert output =~ "no critical node data found"
+    refute File.exists?(context.backup_dir)
+  end
+
+  test "does not fail removal when backup directory is not writable", context do
+    File.mkdir_p!(context.snap_user_data)
+    File.write!(Path.join(context.snap_user_data, "node"), "diode_node@test.diode\n")
+
+    env = [
+      {"SNAP_DATA", context.snap_data},
+      {"SNAP_USER_DATA", context.snap_user_data},
+      {"SNAP_NAME", "diode-node"},
+      {"BACKUP_DIR", "/root/diode-node-backup-should-not-exist"}
+    ]
+
+    {output, 0} =
+      System.cmd("bash", [@script], env: env, stderr_to_stdout: true)
+
+    assert output =~ "cannot create backup directory"
+    assert output =~ "snap saved"
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #2

When a user runs `snap remove diode-node`, the snap's data directories are deleted and wallet access can be lost permanently. This PR adds an automatic backup that runs in the snap `remove` hook before data is wiped.

## Approach

This follows the design in issue #2:

1. **`remove` hook** (`snap/hooks/remove`) runs before snap data deletion and invokes the backup script bundled in the snap.
2. **`backup-dir` plug** requests write access to `/var/backups/diode-node` via the `system-files` interface.
3. **Backup script** (`scripts/snap_backup_on_remove.sh`) archives the critical resurrection files:
   - `$SNAP_USER_DATA/node` (node identity)
   - `$SNAP_DATA/nodedata_*` (wallet/database)
4. **Fallback UX**: if the backup directory cannot be written (plug not connected), the hook logs a warning pointing users to `snap saved` / `snap restore` within the 31-day snapd retention window — removal still succeeds.
5. **Restore helper** (`scripts/restore_snap_backup.sh`, installed as `bin/restore_snap_backup`) and README documentation for manual recovery.

Note: `erl_inetrc` is intentionally excluded — DNS config is regenerated on service start and is not required to resurrect the node.

## Business case

Users who uninstall the snap without knowing about wallet persistence lose access to their node identity and funds. Automatic backup on removal makes recovery possible without requiring users to know about manual `snap save` procedures upfront.

## Demo

Simulated snap-removal flow (mock `$SNAP_DATA` / `$SNAP_USER_DATA` directories):

### 1. Critical files present before removal

![Simulated snap data before removal showing node identity, erl_inetrc, and nodedata_prod wallet files](https://cursor.com/artifacts/c/art-68d08d45-25fb-4b78-a83b-dc070af32dd4)

### 2. Remove hook creates secure backup archive

![Remove hook backup success message and backup tarball with 0600 permissions in /var/backups/diode-node](https://cursor.com/artifacts/c/art-af381d19-c6ed-4d4c-b18f-f31edfeeff29)

### 3. Archive preserves resurrection files + manifest

![Tarball contents listing snap_user_data, snap_data/nodedata_prod, and manifest.txt](https://cursor.com/artifacts/c/art-ddc18069-964d-43e7-9542-97e21edccbea)

### 4. Restore after reinstall

![Restore script recovering node identity and wallet data into fresh snap directories](https://cursor.com/artifacts/c/art-c9b790be-2d04-4539-a315-8250d5f95e45)

### 5. Fallback when backup-dir plug is not connected

![Fallback warning when backup directory is not writable, pointing to snap saved within 31 days](https://cursor.com/artifacts/c/art-4bb8cf42-9e08-4805-9ff9-5dfbe7ee0070)

## Testing

Added `test/snap_backup_on_remove_test.exs` covering:
- Tarball creation with node identity and nodedata, secure permissions (`0600`)
- Explicit exclusion of `erl_inetrc` even when present
- Skip when no data exists
- Graceful handling when backup directory is not writable

Validated locally with bash integration tests mirroring the ExUnit cases.

## Notes

- Auto-connection for the `backup-dir` system-files plug will need a separate Snap Store forum request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a955d701-cc27-46b0-81d5-8a269732acd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a955d701-cc27-46b0-81d5-8a269732acd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

