### PR TITLE
Fix ticket wire encoding after device_address cache regression

### DIFF
--- a/lib/kademlia_light.ex
+++ b/lib/kademlia_light.ex
@@ -41,7 +41,7 @@ defmodule KademliaLight do
 
   def store(object) when is_tuple(object) do
     key = Object.key(object)
-    value = Object.encode!(object)
+    value = Object.Wire.encode!(object)
     store(key, value)
   end
 

--- a/lib/model/kademliasql.ex
+++ b/lib/model/kademliasql.ex
@@ -374,25 +374,25 @@ defmodule Model.KademliaSql do
       # querying stale objects to ensure we won't re-store a stale object
       case stale_object_ext(hkey) do
         nil ->
-          put_object(hkey, Object.encode!(object))
+          put_object(hkey, Object.Wire.encode!(object))
 
         {existing, stale?} ->
           existing_object = Object.decode!(existing)
 
           case {Object.modname(existing_object), Object.modname(object)} do
             {Object.TicketV1, Object.TicketV2} ->
-              put_object(hkey, Object.encode!(object))
+              put_object(hkey, Object.Wire.encode!(object))
 
             {Object.TicketV2, Object.TicketV1} ->
               existing_object
 
             _ ->
               if Object.block_number(existing_object) < Object.block_number(object) do
-                put_object(hkey, Object.encode!(object))
+                put_object(hkey, Object.Wire.encode!(object))
               else
                 if force_refresh and
                      Object.block_number(existing_object) == Object.block_number(object) do
-                  put_object(hkey, Object.encode!(object))
+                  put_object(hkey, Object.Wire.encode!(object))
                 else
                   if stale? do
                     nil

--- a/lib/network/edge_v2.ex
+++ b/lib/network/edge_v2.ex
@@ -442,10 +442,10 @@ defmodule Network.EdgeV2 do
               case KademliaLight.find_value(key) do
                 nil ->
                   KademliaLight.store(obj)
-                  Object.encode_list!(obj)
+                  Object.Wire.encode_list!(obj)
 
                 binary ->
-                  Object.encode_list!(Object.decode!(binary))
+                  Object.Wire.encode_list!(Object.decode!(binary))
               end
               |> response()
           end
@@ -456,20 +456,20 @@ defmodule Network.EdgeV2 do
 
         ["getobject", key] ->
           with binary when binary != nil <- KademliaLight.find_value(key) do
-            Object.encode_list!(Object.decode!(binary))
+            Object.Wire.encode_list!(Object.decode!(binary))
           end
           |> response()
 
         ["getnode", node] ->
           with object when object != nil <- KademliaLight.find_node_object(node) do
-            Object.encode_list!(object)
+            Object.Wire.encode_list!(object)
           end
           |> response()
 
         ["getnodes", node] ->
           node
           |> KademliaLight.find_node_objects()
-          |> Enum.map(&Object.encode_list!/1)
+          |> Enum.map(&Object.Wire.encode_list!/1)
           |> response()
 
         ["portopen", device_id, port, flags] ->

--- a/lib/network/peer_handler_v2.ex
+++ b/lib/network/peer_handler_v2.ex
@@ -153,7 +153,7 @@ defmodule Network.PeerHandlerV2 do
     # We don't have server registration atm
     chain_id = 0
 
-    {:noreply, state} = ssl_send(state, [@hello, Object.encode!(hello), chain_id, []])
+    {:noreply, state} = ssl_send(state, [@hello, Object.Wire.encode!(hello), chain_id, []])
 
     receive do
       {:ssl, _socket, msg} ->

--- a/lib/network/rpc.ex
+++ b/lib/network/rpc.ex
@@ -279,7 +279,7 @@ defmodule Network.Rpc do
 
         case KademliaLight.find_value(key) do
           nil -> result(nil, 404)
-          binary -> result(Object.encode_list!(Object.decode!(binary)))
+          binary -> result(Object.Wire.encode_list!(Object.decode!(binary)))
         end
 
       "dio_getNode" ->
@@ -287,7 +287,7 @@ defmodule Network.Rpc do
 
         case KademliaLight.find_node_object(node) do
           nil -> result(nil, 404)
-          object -> result(Object.encode_list!(object))
+          object -> result(Object.Wire.encode_list!(object))
         end
 
       "dio_traffic" ->
@@ -362,7 +362,7 @@ defmodule Network.Rpc do
 
         tickets =
           TicketStore.tickets(chain_id, epoch)
-          |> Enum.map(&Object.encode!/1)
+          |> Enum.map(&Object.Wire.encode!/1)
           |> Enum.map(&Base16.encode/1)
 
         result(%{

--- a/lib/network/ticket_submission.ex
+++ b/lib/network/ticket_submission.ex
@@ -196,7 +196,7 @@ defmodule Network.TicketSubmission do
     Debouncer.immediate(
       key,
       fn ->
-        Model.KademliaSql.put_object(KademliaLight.hash(key), Object.encode!(ticket))
+        Model.KademliaSql.put_object(KademliaLight.hash(key), Object.Wire.encode!(ticket))
         KademliaLight.store(ticket)
       end,
       15_000

--- a/lib/object/ticket.ex
+++ b/lib/object/ticket.ex
@@ -114,6 +114,12 @@ defmodule DiodeClient.Object.Ticket do
   @spec local_address(raw_t()) :: binary()
   def local_address(tck), do: dispatch(tck, :local_address, [])
 
+  @spec wire_encode!(raw_t()) :: binary()
+  def wire_encode!(tck), do: DiodeClient.BertExt.encode!(wire_encode_list!(tck))
+
+  @spec wire_encode_list!(raw_t()) :: list()
+  def wire_encode_list!(tck), do: dispatch(tck, :wire_list, [])
+
   def score(tck), do: total_connections(tck) * 1024 + total_bytes(tck)
 
   def too_many_bytes?(tck) do

--- a/lib/object/ticketv1.ex
+++ b/lib/object/ticketv1.ex
@@ -44,6 +44,24 @@ defmodule DiodeClient.Object.TicketV1 do
           )
   @type raw :: t() | tuple()
 
+  @doc false
+  @spec wire_list(raw()) :: list()
+  def wire_list(tck) do
+    tck = normalize(tck)
+
+    [
+      "ticket",
+      server_id(tck),
+      block_number(tck),
+      fleet_contract(tck),
+      total_connections(tck),
+      total_bytes(tck),
+      local_address(tck),
+      device_signature(tck),
+      server_signature(tck)
+    ]
+  end
+
   @spec normalize(tuple()) :: t()
   def normalize(t = ticketv1()), do: t
 

--- a/lib/object/ticketv1.ex
+++ b/lib/object/ticketv1.ex
@@ -47,18 +47,27 @@ defmodule DiodeClient.Object.TicketV1 do
   @doc false
   @spec wire_list(raw()) :: list()
   def wire_list(tck) do
-    tck = normalize(tck)
+    ticketv1(
+      server_id: server_id,
+      block_number: block_number,
+      fleet_contract: fleet_contract,
+      total_connections: total_connections,
+      total_bytes: total_bytes,
+      local_address: local_address,
+      device_signature: device_signature,
+      server_signature: server_signature
+    ) = normalize(tck)
 
     [
       "ticket",
-      server_id(tck),
-      block_number(tck),
-      fleet_contract(tck),
-      total_connections(tck),
-      total_bytes(tck),
-      local_address(tck),
-      device_signature(tck),
-      server_signature(tck)
+      server_id,
+      block_number,
+      fleet_contract,
+      total_connections,
+      total_bytes,
+      local_address,
+      device_signature,
+      server_signature
     ]
   end
 

--- a/lib/object/ticketv2.ex
+++ b/lib/object/ticketv2.ex
@@ -55,6 +55,25 @@ defmodule DiodeClient.Object.TicketV2 do
     )
   end
 
+  @doc false
+  @spec wire_list(raw()) :: list()
+  def wire_list(tck) do
+    tck = normalize(tck)
+
+    [
+      "ticketv2",
+      server_id(tck),
+      chain_id(tck),
+      epoch(tck),
+      fleet_contract(tck),
+      total_connections(tck),
+      total_bytes(tck),
+      local_address(tck),
+      device_signature(tck),
+      server_signature(tck)
+    ]
+  end
+
   @impl true
   def key(tck) do
     tck = normalize(tck)

--- a/lib/object/ticketv2.ex
+++ b/lib/object/ticketv2.ex
@@ -58,19 +58,29 @@ defmodule DiodeClient.Object.TicketV2 do
   @doc false
   @spec wire_list(raw()) :: list()
   def wire_list(tck) do
-    tck = normalize(tck)
+    ticketv2(
+      server_id: server_id,
+      chain_id: chain_id,
+      epoch: epoch,
+      fleet_contract: fleet_contract,
+      total_connections: total_connections,
+      total_bytes: total_bytes,
+      local_address: local_address,
+      device_signature: device_signature,
+      server_signature: server_signature
+    ) = normalize(tck)
 
     [
       "ticketv2",
-      server_id(tck),
-      chain_id(tck),
-      epoch(tck),
-      fleet_contract(tck),
-      total_connections(tck),
-      total_bytes(tck),
-      local_address(tck),
-      device_signature(tck),
-      server_signature(tck)
+      server_id,
+      chain_id,
+      epoch,
+      fleet_contract,
+      total_connections,
+      total_bytes,
+      local_address,
+      device_signature,
+      server_signature
     ]
   end
 

--- a/lib/object/wire.ex
+++ b/lib/object/wire.ex
@@ -1,0 +1,26 @@
+# Diode Server
+# Copyright 2021-2024 Diode
+# Licensed under the Diode License, Version 1.1
+defmodule DiodeClient.Object.Wire do
+  @moduledoc false
+  alias DiodeClient.{BertExt, Object, Object.Ticket}
+
+  @ticket_tags [:ticketv1, :ticketv2]
+
+  @spec encode!(tuple()) :: binary()
+  def encode!(object) do
+    encode_list!(object)
+    |> BertExt.encode!()
+  end
+
+  @spec encode_list!(tuple()) :: list()
+  def encode_list!(object) when is_tuple(object) do
+    case elem(object, 0) do
+      type when type in @ticket_tags ->
+        Ticket.wire_encode_list!(Ticket.normalize(object))
+
+      _ ->
+        Object.encode_list!(object)
+    end
+  end
+end

--- a/lib/object/wire.ex
+++ b/lib/object/wire.ex
@@ -17,7 +17,7 @@ defmodule DiodeClient.Object.Wire do
   def encode_list!(object) when is_tuple(object) do
     case elem(object, 0) do
       type when type in @ticket_tags ->
-        Ticket.wire_encode_list!(Ticket.normalize(object))
+        Ticket.wire_encode_list!(object)
 
       _ ->
         Object.encode_list!(object)

--- a/test/object/ticket_device_address_cache_test.exs
+++ b/test/object/ticket_device_address_cache_test.exs
@@ -6,7 +6,7 @@ defmodule DiodeClient.Object.TicketDeviceAddressCacheTest do
   import TestHelper
   alias DiodeClient.Object.Ticket
   alias DiodeClient.Object.TicketV2
-  alias DiodeClient.{Secp256k1, Wallet}
+  alias DiodeClient.{Object, Secp256k1, Wallet}
   import TicketV2, only: [ticketv2: 1]
   import Edge2Client, only: [clientid: 1]
 
@@ -136,6 +136,31 @@ defmodule DiodeClient.Object.TicketDeviceAddressCacheTest do
     Supervisor.terminate_child(Diode.Supervisor, TicketStore)
 
     assert {:ok, _pid} = Supervisor.restart_child(Diode.Supervisor, TicketStore)
+  end
+
+  test "wire encode excludes internal device_address from edge object format" do
+    wallet = clientid(1)
+    device = Wallet.address!(wallet)
+    ticket = build_ticket(wallet)
+    cached = Ticket.with_device_address(ticket, device)
+
+    assert Ticket.device_address(cached) == device
+
+    assert length(Object.encode_list!(cached)) == 11
+
+    wire = Object.Wire.encode_list!(cached)
+    assert length(wire) == 10
+    assert hd(wire) == "ticketv2"
+    assert List.last(wire) == Ticket.server_signature(cached)
+
+    legacy = legacy_tuple(ticket)
+    assert Object.Wire.encode_list!(legacy) == wire
+
+    roundtrip = Object.decode!(Object.Wire.encode!(cached))
+    assert Ticket.mod(roundtrip) == DiodeClient.Object.TicketV2
+    assert Ticket.server_id(roundtrip) == Ticket.server_id(cached)
+    assert Ticket.epoch(roundtrip) == Ticket.epoch(cached)
+    assert Ticket.device_signature(roundtrip) == Ticket.device_signature(cached)
   end
 
   test "submit and too_low behaviour unchanged with cached device_address" do

--- a/test/object_test.exs
+++ b/test/object_test.exs
@@ -101,7 +101,7 @@ defmodule ObjectTest do
         device_signature: <<0::520>>,
         server_signature: <<0::520>>
       )
-      |> Object.encode!()
+      |> Object.Wire.encode!()
 
     Model.KademliaSql.put_object(key, ticket)
     key


### PR DESCRIPTION
## Summary
- Fixes a regression from the `device_address` cache field where `Object.encode_list!/1` included an extra list element on ticketv2 responses, breaking Go client `connectDevice` / `getobject` decoding.
- Adds `TicketV1.wire_list/1`, `TicketV2.wire_list/1`, and `Object.Wire` so all Kademlia and Edge encode paths emit the canonical wire format while keeping `device_address` internal-only.
- Adds a regression test asserting cached tickets encode to 10 fields via `Object.Wire` (not 11 via raw `Object.encode_list!/1`).

## Test plan
- [x] `mix test test/object/ticket_device_address_cache_test.exs test/object_test.exs`
- [ ] Deploy to a node and verify `connectDevice` succeeds against a device with a cached ticket
- [ ] Confirm existing Kademlia-stored tickets still round-trip through `getobject`


Made with [Cursor](https://cursor.com)