### PR TITLE
Resolve wallet factory address per chain for CreateIdentity

### DIFF
--- a/lib/remote_chain/edge.ex
+++ b/lib/remote_chain/edge.ex
@@ -6,7 +6,9 @@ defmodule RemoteChain.Edge do
   import Network.EdgeV2, only: [response: 1, response: 2, error: 1]
   require Logger
 
-  def wallet_factory_address(), do: Base16.decode("0x1E568739AF8FD8FE0748DEFB74A917EA9D38FE29")
+  def wallet_factory_address(chain) do
+    DiodeClient.Contracts.Factory.address(DiodeClient.shell_for_chain_id(chain.chain_id()))
+  end
 
   def handle_async_msg(chain, msg, state) do
     case msg do
@@ -134,7 +136,7 @@ defmodule RemoteChain.Edge do
         if CallPermitAdapter.should_forward_metatransaction?(chain) do
           CallPermitAdapter.forward_metatransaction(chain, tx)
         else
-          {to, call, sender, min_gas_limit} = prepare_metatransaction(Rlp.decode!(tx))
+          {to, call, sender, min_gas_limit} = prepare_metatransaction(chain, Rlp.decode!(tx))
           send_metatransaction(chain, to, call, sender, min_gas_limit)
         end
 
@@ -247,7 +249,7 @@ defmodule RemoteChain.Edge do
   end
 
   @default_gas_limit 1_000_000
-  defp prepare_metatransaction(["dm0", owner, salt, impl]) do
+  defp prepare_metatransaction(chain, ["dm0", owner, salt, impl]) do
     target = impl
 
     call =
@@ -257,10 +259,10 @@ defmodule RemoteChain.Edge do
         [owner, salt, target]
       )
 
-    {wallet_factory_address(), call, owner, @default_gas_limit}
+    {wallet_factory_address(chain), call, owner, @default_gas_limit}
   end
 
-  defp prepare_metatransaction(["dm1", sender, id, nonce, deadline, dst, data, v, r, s]) do
+  defp prepare_metatransaction(_chain, ["dm1", sender, id, nonce, deadline, dst, data, v, r, s]) do
     nonce = Rlpx.bin2uint(nonce)
     deadline = Rlpx.bin2uint(deadline)
     v = Rlpx.bin2uint(v)
@@ -277,7 +279,7 @@ defmodule RemoteChain.Edge do
     {id, call, sender, @default_gas_limit}
   end
 
-  defp prepare_metatransaction([from, to, value, call, gaslimit, deadline, v, r, s]) do
+  defp prepare_metatransaction(_chain, [from, to, value, call, gaslimit, deadline, v, r, s]) do
     # These are CallPermit metatransactions
     # Testing transaction
     value = Rlpx.bin2uint(value)

--- a/scripts/trace.exs
+++ b/scripts/trace.exs
@@ -61,6 +61,17 @@ defmodule Anvil do
 end
 
 defmodule Trace do
+  defp wallet_factory_address do
+    chain =
+      case System.get_env("CHAIN") do
+        "moonbeam" -> Chains.Moonbeam
+        "base" -> Chains.Base
+        _ -> Chains.OasisSapphire
+      end
+
+    RemoteChain.Edge.wallet_factory_address(chain)
+  end
+
   def trace_block(block_number) do
     IO.puts("Block Number: #{block_number}")
 
@@ -69,7 +80,7 @@ defmodule Trace do
         Enum.each(transactions, fn tx ->
           if tx["to"] in [
                Base16.encode(CallPermit.address()),
-               Base16.encode(RemoteChain.Edge.wallet_factory_address())
+               Base16.encode(wallet_factory_address())
              ] do
             trace_tx(tx["hash"])
           end
@@ -131,7 +142,7 @@ defmodule Trace do
         data: input,
         from: owner,
         deadline: nil,
-        to: RemoteChain.Edge.wallet_factory_address()
+        to: wallet_factory_address()
       }
     end
   end
@@ -156,7 +167,7 @@ defmodule Trace do
 
     if tx["to"] not in [
          Base16.encode(CallPermit.address()),
-         Base16.encode(RemoteChain.Edge.wallet_factory_address())
+         Base16.encode(wallet_factory_address())
        ] do
       IO.inspect(tx, label: "tx")
       raise "Not a CallPermit"

--- a/scripts/trace.exs
+++ b/scripts/trace.exs
@@ -342,8 +342,12 @@ case List.first(System.argv()) do
       "https://moonbeam.api.onfinality.io/rpc?apikey=49e8baf7-14c3-4d0f-916a-94abf1c4c14a"
     )
 
+  "base" ->
+    System.put_env("CHAIN", "base")
+    System.put_env("RPC_URL", "https://mainnet.base.org")
+
   _ ->
-    raise "Usage: trace (oasis|moonbeam) <tx_hash>"
+    raise "Usage: trace (oasis|moonbeam|base) <tx_hash>"
 end
 
 # {:ok, _anvil} = Anvil.start_link(System.get_env("RPC_URL"))
@@ -352,7 +356,7 @@ end
 case tl(System.argv()) do
   ["0x" <> _ = tx_hash] -> Trace.trace_tx(tx_hash)
   [block_number] -> Trace.trace_block(String.to_integer(block_number))
-  _ -> raise "Usage: trace (oasis|moonbeam) <tx_hash>"
+  _ -> raise "Usage: trace (oasis|moonbeam|base) <tx_hash>"
 end
 
 # Anvil.stop(anvil)

--- a/test/remote_chain/edge_test.exs
+++ b/test/remote_chain/edge_test.exs
@@ -28,4 +28,19 @@ defmodule RemoteChain.EdgeTest do
                    end
     end
   end
+
+  describe "wallet_factory_address/1" do
+    test "returns the Oasis factory for OasisSapphire" do
+      assert Edge.wallet_factory_address(Chains.OasisSapphire) ==
+               DiodeClient.Contracts.Factory.address(DiodeClient.Shell.OasisSapphire)
+    end
+
+    test "returns the Base factory for Base" do
+      assert Edge.wallet_factory_address(Chains.Base) ==
+               DiodeClient.Contracts.Factory.address(DiodeClient.Shell.Base)
+
+      assert Edge.wallet_factory_address(Chains.Base) !=
+               Edge.wallet_factory_address(Chains.OasisSapphire)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `wallet_factory_address/1` now takes the chain and resolves the factory via `DiodeClient.Contracts.Factory` instead of a hardcoded Oasis address.
- Pass `chain` through `prepare_metatransaction/2` so Base `dm0` CreateIdentity requests target the Base factory (`0x1a36092d…`).
- Update `scripts/trace.exs` and add tests covering Oasis vs Base factory selection.

Without this, Base identity creation succeeds on-chain as a no-op against an empty account, so Base meta-nonces never advance and clients keep pending txs in the UI.

## Test plan
- [x] `mix test test/remote_chain/edge_test.exs test/chains/base_test.exs`
- [ ] Deploy to a relay and confirm Base `CreateIdentityRequest` receipt `to` is `0x1a36092d88fb73692ee7c502978d634c4afcc486`
- [ ] Confirm Base identity has code / account root after create, and subsequent meta-txs settle in the client UI