### PR TITLE
Fix eth_getStorageAt batch QUANTITY encoding for Base RPC

### DIFF
--- a/lib/remote_chain/rpc_cache.ex
+++ b/lib/remote_chain/rpc_cache.ex
@@ -88,7 +88,7 @@ defmodule RemoteChain.RPCCache do
     # for storage requests we use the last change block as the base
     # any contract not using change tracking will suffer 240 blocks (one hour) of caching
     block = get_last_change(chain, address, block)
-    rpc!(chain, "eth_getStorageAt", [address, slot, Base16.encode(block, false)])
+    rpc!(chain, "eth_getStorageAt", [address, slot, block])
   end
 
   def get_storage_many(chain, address, slots, block \\ "latest") do
@@ -102,7 +102,8 @@ defmodule RemoteChain.RPCCache do
 
     cache_results =
       Enum.map(slots, fn slot ->
-        {:rpc, "eth_getStorageAt", [address, slot, Base16.encode(block, false)]}
+        # batch_call skips rpc/3, so normalize here (QUANTITY must have no leading zeros)
+        {:rpc, "eth_getStorageAt", normalize_args(chain, "eth_getStorageAt", [address, slot, block])}
       end)
       |> Enum.map(fn rpc = {:rpc, method, params} ->
         with %{"result" => result} <- Cache.get(cache, {chain, method, params}) do
@@ -176,34 +177,37 @@ defmodule RemoteChain.RPCCache do
   def get_balance(chain, address, block \\ "latest"),
     do: rpc!(chain, "eth_getBalance", [address, block])
 
-  defp normalize_args(chain, "eth_getBalance", [address, block]) do
+  # Also used by get_storage_many before batch_call (which skips rpc/3).
+  @doc false
+  def normalize_args(chain, "eth_getBalance", [address, block]) do
     [address, normalize_block(chain, block)]
   end
 
-  defp normalize_args(chain, "eth_getTransactionCount", [address, block]) do
+  def normalize_args(chain, "eth_getTransactionCount", [address, block]) do
     [address, normalize_block(chain, block)]
   end
 
-  defp normalize_args(chain, "eth_getBlockByNumber", [block, with_transactions]) do
+  def normalize_args(chain, "eth_getBlockByNumber", [block, with_transactions]) do
     [normalize_block(chain, block), with_transactions]
   end
 
-  defp normalize_args(chain, "eth_call", [opts, block]) do
+  def normalize_args(chain, "eth_call", [opts, block]) do
     [opts, normalize_block(chain, block)]
   end
 
-  defp normalize_args(chain, "eth_getCode", [address, block]) do
+  def normalize_args(chain, "eth_getCode", [address, block]) do
     [address, normalize_block(chain, block)]
   end
 
-  defp normalize_args(chain, "eth_getStorageAt", [address, slot, block]) do
+  def normalize_args(chain, "eth_getStorageAt", [address, slot, block]) do
     [address, slot, normalize_block(chain, block)]
   end
 
-  defp normalize_args(_chain, _method, args) do
+  def normalize_args(_chain, _method, args) do
     args
   end
 
+  # JSON-RPC QUANTITY: no leading zeros. Padded "0x02f1cf00" is rejected as -32602 on Base.
   defp normalize_block(chain, block) do
     Base16.encode(resolve_block(chain, block), short: true)
   end
@@ -253,7 +257,7 @@ defmodule RemoteChain.RPCCache do
     rpc!(chain, "eth_getStorageAt", [
       address,
       "0x1e4717b2dc5dfd7f487f2043bfe9999372d693bf4d9c51b5b84f1377939cd487",
-      Base16.encode(block, false)
+      block
     ])
     |> Base16.decode_int()
     |> case do

--- a/lib/remote_chain/rpc_cache.ex
+++ b/lib/remote_chain/rpc_cache.ex
@@ -103,7 +103,8 @@ defmodule RemoteChain.RPCCache do
     cache_results =
       Enum.map(slots, fn slot ->
         # batch_call skips rpc/3, so normalize here (QUANTITY must have no leading zeros)
-        {:rpc, "eth_getStorageAt", normalize_args(chain, "eth_getStorageAt", [address, slot, block])}
+        {:rpc, "eth_getStorageAt",
+         normalize_args(chain, "eth_getStorageAt", [address, slot, block])}
       end)
       |> Enum.map(fn rpc = {:rpc, method, params} ->
         with %{"result" => result} <- Cache.get(cache, {chain, method, params}) do

--- a/scripts/bns.exs
+++ b/scripts/bns.exs
@@ -212,9 +212,7 @@ for chunk <- missing do
     )
     |> Base16.decode_int()
 
-  IO.puts(
-    "Wallet: #{Base16.encode(Wallet.address!(wallet))} Nonce: #{nonce} Balance: #{balance}"
-  )
+  IO.puts("Wallet: #{Base16.encode(Wallet.address!(wallet))} Nonce: #{nonce} Balance: #{balance}")
 
   {txs, _next_nonce} =
     Enum.reduce(chunk, {[], nonce}, fn {name, owner, _identity, _deployed?, slot}, {acc, n} ->

--- a/test/remote_chain/rpc_cache_test.exs
+++ b/test/remote_chain/rpc_cache_test.exs
@@ -1,0 +1,20 @@
+# Diode Server
+# Copyright 2021-2024 Diode
+# Licensed under the Diode License, Version 1.1
+defmodule RemoteChain.RPCCacheTest do
+  use ExUnit.Case, async: true
+
+  describe "normalize_args/3 for eth_getStorageAt" do
+    test "uses short QUANTITY block encoding (Base rejects padded hex like 0x02f1cf00)" do
+      # get_storage_many batch_call skips rpc/3; it must still run normalize_args.
+      address = "0xda92764bb12e91010d132bcdd8e4a0270ee25fc9"
+      slot = "0xc9f6766ee659edc5eddd04b71e82c56aa865e95b4ae66f7ebe9a16071844b44a"
+
+      assert RemoteChain.RPCCache.normalize_args(Chains.Anvil, "eth_getStorageAt", [
+               address,
+               slot,
+               49_401_600
+             ]) == [address, slot, "0x2f1cf00"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `get_storage_many` was sending padded block hex (e.g. `0x02f1cf00`) via `batch_call`, which bypasses `rpc/3`/`normalize_args`.
- Strict Base RPC providers reject that as `-32602 invalid params`, raising in EdgeV2 and dropping the connection.
- Route batch storage params through `normalize_args` so blocks use short JSON-RPC QUANTITY encoding (`0x2f1cf00`).

## Test plan
- [x] `DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/rpc_cache_test.exs`
- [ ] Confirm Base `getaccountvalues` / storage reads no longer crash EdgeV2 with `-32602`


Made with [Cursor](https://cursor.com)