### PR TITLE
Replace geometric redistribute with nearest-N anti-entropy

### DIFF
--- a/lib/kademlia_light.ex
+++ b/lib/kademlia_light.ex
@@ -440,13 +440,11 @@ defmodule KademliaLight do
   defp queue_join_catchup(node) do
     Debouncer.apply(
       {:join_catchup, node.address},
-      fn -> join_catchup(node) end,
+      fn ->
+        join_catchup_with_rpc(node, &rpc/2, ready_connections(), ring_nodes())
+      end,
       @join_catchup_debounce
     )
-  end
-
-  defp join_catchup(%Node{} = node) do
-    join_catchup_with_rpc(node, &rpc/2, ready_connections(), ring_nodes())
   end
 
   defp join_catchup_with_rpc(%Node{} = node, rpc_fun, ready, ring)
@@ -454,76 +452,71 @@ defmodule KademliaLight do
     if not Map.has_key?(ready, node.address) do
       []
     else
-      KademliaSql.objects_page(nil, @anti_entropy_batch)
-      |> Enum.filter(fn {key, value} ->
-        nearest = KademliaRing.nearest_n(ring, key, @n)
-
-        if Enum.any?(nearest, fn %Node{address: addr} -> addr == node.address end) do
-          rpc_fun.([node], [PeerHandlerV2.store(), key, value])
-          true
-        else
-          false
-        end
-      end)
-      |> Enum.map(&elem(&1, 0))
+      for {key, value} <- KademliaSql.objects_page(nil, @anti_entropy_batch),
+          in_nearest_n?(ring, key, node.address) do
+        rpc_fun.([node], [PeerHandlerV2.store(), key, value])
+        key
+      end
     end
   end
 
   defp run_anti_entropy do
-    cursor = anti_entropy_cursor()
+    cursor =
+      case :ets.lookup(@ets_table, :anti_entropy_cursor) do
+        [{:anti_entropy_cursor, cursor}] -> cursor
+        _ -> nil
+      end
 
-    {repaired, next_cursor} =
-      do_anti_entropy(cursor, @anti_entropy_batch, &rpc/2, nil, ring_nodes())
+    ready = ready_connections()
 
-    put_anti_entropy_cursor(next_cursor)
+    {attempted, next_cursor} =
+      do_anti_entropy(cursor, @anti_entropy_batch, &rpc/2, ready, ring_nodes())
 
-    if repaired != [] do
+    :ets.insert(@ets_table, {:anti_entropy_cursor, next_cursor})
+
+    if attempted != [] do
       Logger.info(
-        "Anti-entropy: repaired #{length(repaired)} object(s) (batch=#{@anti_entropy_batch})"
+        "Anti-entropy: attempted #{length(attempted)} object(s) (batch=#{@anti_entropy_batch})"
       )
     end
 
-    {repaired, next_cursor}
+    :ok
   end
 
   defp do_anti_entropy(cursor, batch, rpc_fun, ready, ring)
        when is_integer(batch) and is_function(rpc_fun, 2) and is_list(ring) do
     page = KademliaSql.objects_page(cursor, batch)
 
-    repaired =
-      Enum.filter(page, fn {key, value} ->
-        nearest = KademliaRing.nearest_n(ring, key, @n)
-
-        if Enum.any?(nearest, &KademliaRing.is_self/1) do
-          repair_replicas_with_rpc(key, value, rpc_fun, ready)
-          true
-        else
-          false
-        end
-      end)
-      |> Enum.map(&elem(&1, 0))
-
-    next_cursor =
-      case List.last(page) do
-        nil ->
-          nil
-
-        {key, _} ->
-          if length(page) < batch, do: nil, else: key
+    attempted =
+      for {key, value} <- page, in_nearest_n?(ring, key, :self) do
+        repair_replicas_with_rpc(key, value, rpc_fun, ready)
+        key
       end
 
-    {repaired, next_cursor}
+    {attempted, next_page_cursor(page, batch)}
   end
 
-  defp anti_entropy_cursor do
-    case :ets.lookup(@ets_table, :anti_entropy_cursor) do
-      [{:anti_entropy_cursor, cursor}] -> cursor
-      _ -> nil
+  defp next_page_cursor([], _batch), do: nil
+
+  defp next_page_cursor(page, batch) do
+    if length(page) < batch do
+      nil
+    else
+      {key, _} = List.last(page)
+      key
     end
   end
 
-  defp put_anti_entropy_cursor(cursor) do
-    :ets.insert(@ets_table, {:anti_entropy_cursor, cursor})
+  defp in_nearest_n?(ring, key, :self) do
+    ring
+    |> KademliaRing.nearest_n(key, @n)
+    |> Enum.any?(&KademliaRing.is_self/1)
+  end
+
+  defp in_nearest_n?(ring, key, address) when is_binary(address) do
+    ring
+    |> KademliaRing.nearest_n(key, @n)
+    |> Enum.any?(fn %Node{address: addr} -> addr == address end)
   end
 
   defp load_ring() do

--- a/lib/kademlia_light.ex
+++ b/lib/kademlia_light.ex
@@ -21,7 +21,9 @@ defmodule KademliaLight do
   @w 2
   @r 1
   @ets_table :kademlia_network
-  @redistribute_interval :timer.minutes(2)
+  @anti_entropy_interval :timer.minutes(5)
+  @anti_entropy_batch 100
+  @join_catchup_debounce :timer.minutes(2)
   @contact_interval :timer.minutes(1)
   @discover_batch 40
   @discover_throttle_seconds 3600
@@ -146,18 +148,11 @@ defmodule KademliaLight do
     GenServer.call(__MODULE__, {:drop_nodes, keys}, 60_000)
   end
 
-  def redistribute_removed_node(address) do
-    Debouncer.apply(
-      {:redistribute_removed, address},
-      fn ->
-        node = Node.new(Wallet.from_address(address))
-
-        spawn(__MODULE__, :redistribute_stale, [
-          ring_nodes(),
-          node
-        ])
-      end,
-      :timer.minutes(2)
+  def kick_anti_entropy do
+    Debouncer.immediate2(
+      :anti_entropy,
+      fn -> run_anti_entropy() end,
+      @anti_entropy_interval
     )
   end
 
@@ -213,7 +208,7 @@ defmodule KademliaLight do
     state = %{state | ring: ring}
 
     :timer.send_interval(@contact_interval, :contact_nodes)
-    :timer.send_interval(@redistribute_interval, :scan_redistribution)
+    :timer.send_interval(@anti_entropy_interval, :anti_entropy)
 
     {:noreply, _} = handle_info(:contact_nodes, state)
     {:noreply, state}
@@ -263,8 +258,7 @@ defmodule KademliaLight do
   def handle_cast({:stable_node, node_id}, state) do
     KademliaSql.mark_stable(node_id)
     update_ets_meta(node_id)
-    node = Node.new(node_id)
-    queue_redistribute(node)
+    queue_join_catchup(Node.new(node_id))
     {:noreply, state}
   end
 
@@ -296,31 +290,9 @@ defmodule KademliaLight do
     {:noreply, state}
   end
 
-  def handle_info(:scan_redistribution, state) do
-    ready = Network.PeerServer.get_ready_connections()
-
-    for {address, _ring_key} <- KademliaSql.nodes_needing_redistribution() do
-      if not Map.has_key?(ready, address) do
-        node = Node.new(Wallet.from_address(address))
-
-        Debouncer.apply(
-          {:redistribute_stale, address},
-          fn -> redistribute_stale(ring_nodes(), node) end,
-          :timer.minutes(2)
-        )
-      end
-    end
-
+  def handle_info(:anti_entropy, state) do
+    kick_anti_entropy()
     {:noreply, state}
-  end
-
-  def update_stale_nodes(stale, network) do
-    Process.register(self(), :stale_nodes_updater)
-    Logger.info("Redistributing #{length(stale)} stale nodes")
-
-    for stale_node <- stale do
-      redistribute_stale(network, stale_node)
-    end
   end
 
   def rpc(nodes, call) when is_list(nodes) do
@@ -465,83 +437,93 @@ defmodule KademliaLight do
     GenServer.cast(ensure_node_connection(node), {:rpc, call})
   end
 
-  defp queue_redistribute(node) do
+  defp queue_join_catchup(node) do
     Debouncer.apply(
-      {:redistribute, node.node_id},
-      fn -> redistribute(node) end,
-      :timer.minutes(2)
+      {:join_catchup, node.address},
+      fn -> join_catchup(node) end,
+      @join_catchup_debounce
     )
   end
 
-  @max_key 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-
-  def node_range(node, network \\ ring_nodes()) do
-    online = ready_connections()
-
-    node =
-      case node do
-        %Node{} -> node
-        key -> Enum.find(network, fn n -> KademliaRing.key(n) == KademliaRing.key(key) end)
-      end
-
-    previ =
-      case filter_online(KademliaRing.prev(network, node), online) do
-        [prev | _] -> KademliaRing.integer(prev)
-        [] -> KademliaRing.integer(node)
-      end
-
-    nodei = KademliaRing.integer(node)
-
-    nexti =
-      case filter_online(KademliaRing.next(network, node), online) do
-        [next | _] -> KademliaRing.integer(next)
-        [] -> KademliaRing.integer(node)
-      end
-
-    range_start = rem(div(previ + nodei, 2), @max_key)
-    range_end = rem(div(nexti + nodei, 2), @max_key)
-    {range_start, range_end}
+  defp join_catchup(%Node{} = node) do
+    join_catchup_with_rpc(node, &rpc/2, ready_connections(), ring_nodes())
   end
 
-  defp redistribute(node) do
-    network = ring_nodes()
+  defp join_catchup_with_rpc(%Node{} = node, rpc_fun, ready, ring)
+       when is_function(rpc_fun, 2) and is_map(ready) and is_list(ring) do
+    if not Map.has_key?(ready, node.address) do
+      []
+    else
+      KademliaSql.objects_page(nil, @anti_entropy_batch)
+      |> Enum.filter(fn {key, value} ->
+        nearest = KademliaRing.nearest_n(ring, key, @n)
 
-    if KademliaRing.member?(network, node.node_id) do
-      {range_start, range_end} = node_range(node, network)
-      objs = KademliaSql.objects(range_start, range_end)
-      redist = Enum.shuffle(objs) |> Enum.take(100)
+        if Enum.any?(nearest, fn %Node{address: addr} -> addr == node.address end) do
+          rpc_fun.([node], [PeerHandlerV2.store(), key, value])
+          true
+        else
+          false
+        end
+      end)
+      |> Enum.map(&elem(&1, 0))
+    end
+  end
 
+  defp run_anti_entropy do
+    cursor = anti_entropy_cursor()
+
+    {repaired, next_cursor} =
+      do_anti_entropy(cursor, @anti_entropy_batch, &rpc/2, nil, ring_nodes())
+
+    put_anti_entropy_cursor(next_cursor)
+
+    if repaired != [] do
       Logger.info(
-        "Redistributing #{length(redist)} of #{length(objs)} objects to #{inspect(Wallet.printable(node.node_id))}"
+        "Anti-entropy: repaired #{length(repaired)} object(s) (batch=#{@anti_entropy_batch})"
       )
+    end
 
-      ready = ready_connections()
+    {repaired, next_cursor}
+  end
 
-      if Map.has_key?(ready, node.address) do
-        Enum.each(redist, fn {key, value} ->
-          rpc(node, [PeerHandlerV2.store(), key, value])
-        end)
+  defp do_anti_entropy(cursor, batch, rpc_fun, ready, ring)
+       when is_integer(batch) and is_function(rpc_fun, 2) and is_list(ring) do
+    page = KademliaSql.objects_page(cursor, batch)
+
+    repaired =
+      Enum.filter(page, fn {key, value} ->
+        nearest = KademliaRing.nearest_n(ring, key, @n)
+
+        if Enum.any?(nearest, &KademliaRing.is_self/1) do
+          repair_replicas_with_rpc(key, value, rpc_fun, ready)
+          true
+        else
+          false
+        end
+      end)
+      |> Enum.map(&elem(&1, 0))
+
+    next_cursor =
+      case List.last(page) do
+        nil ->
+          nil
+
+        {key, _} ->
+          if length(page) < batch, do: nil, else: key
       end
+
+    {repaired, next_cursor}
+  end
+
+  defp anti_entropy_cursor do
+    case :ets.lookup(@ets_table, :anti_entropy_cursor) do
+      [{:anti_entropy_cursor, cursor}] -> cursor
+      _ -> nil
     end
   end
 
-  def redistribute_stale(network, %Node{} = node) do
-    {range_start, range_end} = node_range(node, network)
-
-    objs = KademliaSql.objects(range_start, range_end)
-
-    redist =
-      objs
-      |> Enum.shuffle()
-      |> Enum.take(100)
-
-    Logger.info(
-      "Redistributing #{length(redist)} of #{length(objs)} stale objects from #{inspect(Wallet.printable(node.node_id))}"
-    )
-
-    for {key, value} <- redist do
-      repair_replicas(key, value)
-    end
+  defp put_anti_entropy_cursor(cursor) do
+    :ets.insert(@ets_table, {:anti_entropy_cursor, cursor})
   end
 
   defp load_ring() do
@@ -1024,10 +1006,15 @@ defmodule KademliaLight do
   end
 
   defp repair_replicas(key, value) when is_binary(value) do
-    {remote, _} = replica_targets(key)
+    repair_replicas_with_rpc(key, value, &rpc/2, nil)
+  end
+
+  defp repair_replicas_with_rpc(key, value, rpc_fun, online)
+       when is_binary(value) and is_function(rpc_fun, 2) do
+    {remote, _} = replica_targets(key, online)
 
     if remote != [] do
-      results = rpc(remote, [PeerHandlerV2.store(), key, value])
+      results = rpc_fun.(remote, [PeerHandlerV2.store(), key, value])
       repaired = classify_store_results(remote, results).acked
 
       if repaired != [] do
@@ -1067,19 +1054,23 @@ defmodule KademliaLight do
   @doc false
   def repair_replicas_with_rpc_test(key, value, rpc_fun, ready)
       when is_function(rpc_fun, 2) and is_map(ready) do
-    hkey = hash(key)
+    repair_replicas_with_rpc(hash(key), value, rpc_fun, ready)
+  end
 
-    connected =
-      ring_nodes()
-      |> KademliaRing.nearest_n(hkey, @n)
-      |> Enum.reject(&KademliaRing.is_self/1)
-      |> filter_online(ready)
+  @doc false
+  def anti_entropy_with_rpc_test(rpc_fun, ready, opts \\ [])
+      when is_function(rpc_fun, 2) and is_map(ready) do
+    cursor = Keyword.get(opts, :cursor)
+    batch = Keyword.get(opts, :batch, @anti_entropy_batch)
+    ring = Keyword.get(opts, :ring) || ring_nodes()
+    do_anti_entropy(cursor, batch, rpc_fun, ready, ring)
+  end
 
-    if connected != [] do
-      rpc_fun.(connected, [PeerHandlerV2.store(), hkey, value])
-    end
-
-    :ok
+  @doc false
+  def join_catchup_with_rpc_test(node, rpc_fun, ready, opts \\ [])
+      when is_function(rpc_fun, 2) and is_map(ready) do
+    ring = Keyword.get(opts, :ring) || ring_nodes()
+    join_catchup_with_rpc(node, rpc_fun, ready, ring)
   end
 
   @doc false

--- a/lib/model/kademliasql.ex
+++ b/lib/model/kademliasql.ex
@@ -445,52 +445,37 @@ defmodule Model.KademliaSql do
     bstart = <<range_start::integer-size(256)>>
     bend = <<range_end::integer-size(256)>>
 
-    if range_start < range_end do
-      query!(
-        "SELECT key, object FROM p2p_objects WHERE (key >= ?1 AND key <= ?2) AND stored_at > ?3",
-        [bstart, bend, stale_silence_deadline()]
-      )
-    else
-      query!(
-        "SELECT key, object FROM p2p_objects WHERE (key >= ?1 OR key <= ?2) AND stored_at > ?3",
-        [bstart, bend, stale_silence_deadline()]
-      )
-    end
-    |> Enum.reduce([], fn [key, object_blob], acc ->
-      [{key, BertInt.decode!(object_blob)} | acc]
-    end)
-    |> Enum.reverse()
+    rows =
+      if range_start < range_end do
+        query!(
+          "SELECT key, object FROM p2p_objects WHERE (key >= ?1 AND key <= ?2) AND stored_at > ?3",
+          [bstart, bend, stale_silence_deadline()]
+        )
+      else
+        query!(
+          "SELECT key, object FROM p2p_objects WHERE (key >= ?1 OR key <= ?2) AND stored_at > ?3",
+          [bstart, bend, stale_silence_deadline()]
+        )
+      end
+
+    decode_object_rows(rows)
   end
 
   def objects_page(after_key \\ nil, limit \\ 100)
       when is_integer(limit) and limit > 0 do
-    deadline = stale_silence_deadline()
+    query!(
+      """
+      SELECT key, object FROM p2p_objects
+      WHERE stored_at > ?1 AND (?2 IS NULL OR key > ?2)
+      ORDER BY key ASC
+      LIMIT ?3
+      """,
+      [stale_silence_deadline(), after_key, limit]
+    )
+    |> decode_object_rows()
+  end
 
-    rows =
-      case after_key do
-        nil ->
-          query!(
-            """
-            SELECT key, object FROM p2p_objects
-            WHERE stored_at > ?1
-            ORDER BY key ASC
-            LIMIT ?2
-            """,
-            [deadline, limit]
-          )
-
-        key when is_binary(key) ->
-          query!(
-            """
-            SELECT key, object FROM p2p_objects
-            WHERE stored_at > ?1 AND key > ?2
-            ORDER BY key ASC
-            LIMIT ?3
-            """,
-            [deadline, key, limit]
-          )
-      end
-
+  defp decode_object_rows(rows) do
     Enum.map(rows, fn [key, object_blob] ->
       {key, BertInt.decode!(object_blob)}
     end)

--- a/lib/model/kademliasql.ex
+++ b/lib/model/kademliasql.ex
@@ -10,8 +10,6 @@ defmodule Model.KademliaSql do
   import Wallet
   require Logger
 
-  @redistribute_after_seconds 20 * 60
-
   @day_seconds 86_400
   # Don't report after two days
   @stale_silence_seconds @day_seconds * 2
@@ -103,10 +101,6 @@ defmodule Model.KademliaSql do
         |> Enum.map(&hd/1)
         |> Enum.filter(fn addr -> not MapSet.member?(registry_set, addr) end)
 
-      for addr <- removed do
-        KademliaLight.redistribute_removed_node(addr)
-      end
-
       query!("BEGIN IMMEDIATE")
 
       try do
@@ -140,6 +134,11 @@ defmodule Model.KademliaSql do
       end
 
       GenServer.cast(KademliaLight, :reload_ring)
+
+      if removed != [] do
+        KademliaLight.kick_anti_entropy()
+      end
+
       :ok
     end
   end
@@ -310,21 +309,6 @@ defmodule Model.KademliaSql do
     )
   end
 
-  def nodes_needing_redistribution(now \\ now_seconds()) do
-    cutoff = now - @redistribute_after_seconds
-
-    query!(
-      """
-      SELECT address, ring_key FROM p2p_nodes
-      WHERE known_good = 1
-        AND first_failure IS NOT NULL
-        AND first_failure <= ?1
-      """,
-      [cutoff]
-    )
-    |> Enum.map(fn [address, ring_key] -> {address, ring_key} end)
-  end
-
   def delete_nodes_by_ring_keys(keys) when is_list(keys) do
     for key <- keys do
       query!("DELETE FROM p2p_nodes WHERE ring_key = ?1 AND address != ?2", [
@@ -476,6 +460,40 @@ defmodule Model.KademliaSql do
       [{key, BertInt.decode!(object_blob)} | acc]
     end)
     |> Enum.reverse()
+  end
+
+  def objects_page(after_key \\ nil, limit \\ 100)
+      when is_integer(limit) and limit > 0 do
+    deadline = stale_silence_deadline()
+
+    rows =
+      case after_key do
+        nil ->
+          query!(
+            """
+            SELECT key, object FROM p2p_objects
+            WHERE stored_at > ?1
+            ORDER BY key ASC
+            LIMIT ?2
+            """,
+            [deadline, limit]
+          )
+
+        key when is_binary(key) ->
+          query!(
+            """
+            SELECT key, object FROM p2p_objects
+            WHERE stored_at > ?1 AND key > ?2
+            ORDER BY key ASC
+            LIMIT ?3
+            """,
+            [deadline, key, limit]
+          )
+      end
+
+    Enum.map(rows, fn [key, object_blob] ->
+      {key, BertInt.decode!(object_blob)}
+    end)
   end
 
   defp await(chain) do

--- a/test/kademlia_light_anti_entropy_test.exs
+++ b/test/kademlia_light_anti_entropy_test.exs
@@ -23,11 +23,23 @@ defmodule KademliaLightAntiEntropyTest do
     Model.KademliaSql.put_object(hkey, value)
   end
 
+  defp store_rpc(parent, tag) do
+    fn nodes, call ->
+      case call do
+        [:store, key, _value] ->
+          send(parent, {tag, key, Enum.map(nodes, & &1.address)})
+          Enum.map(nodes, fn _ -> ["ok"] end)
+
+        _ ->
+          Enum.map(nodes, fn _ -> [] end)
+      end
+    end
+  end
+
   test "anti-entropy repairs only keys where self is in nearest-N" do
     self = Diode.wallet()
     peers = for _ <- 1..8, do: Wallet.new()
-    addresses = Enum.map(peers, &Wallet.address!/1)
-    assert :ok = Model.KademliaSql.sync_registry_nodes(addresses)
+    assert :ok = Model.KademliaSql.sync_registry_nodes(Enum.map(peers, &Wallet.address!/1))
 
     ring = [Node.new(self) | Enum.map(peers, &Node.new/1)]
     :ets.insert(:kademlia_network, {:ring, ring})
@@ -35,16 +47,12 @@ defmodule KademliaLightAntiEntropyTest do
     candidates =
       for i <- 1..80 do
         hkey = KademliaLight.hash(<<i::256>>)
-        value = data_value(i)
-        put_local(hkey, value)
-        {hkey, value}
+        put_local(hkey, data_value(i))
+        hkey
       end
 
-    # Live GenServer may reload :ring after sync; pin again before classification/run.
-    :ets.insert(:kademlia_network, {:ring, ring})
-
     {owned, foreign} =
-      Enum.split_with(candidates, fn {hkey, _} ->
+      Enum.split_with(candidates, fn hkey ->
         nearest = KademliaRing.nearest_n(ring, hkey, 3)
         Enum.any?(nearest, &KademliaRing.is_self/1)
       end)
@@ -53,73 +61,36 @@ defmodule KademliaLightAntiEntropyTest do
     assert foreign != []
 
     parent = self()
-
-    rpc_fun = fn nodes, call ->
-      case call do
-        [:store, key, _value] ->
-          send(parent, {:store, key, Enum.map(nodes, & &1.address)})
-          Enum.map(nodes, fn _ -> ["ok"] end)
-
-        _ ->
-          Enum.map(nodes, fn _ -> [] end)
-      end
-    end
-
     online = Map.new(peers, fn w -> {Wallet.address!(w), self()} end)
 
-    {repaired, _cursor} =
-      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online, batch: 100, ring: ring)
+    {attempted, _cursor} =
+      KademliaLight.anti_entropy_with_rpc_test(store_rpc(parent, :store), online,
+        batch: 100,
+        ring: ring
+      )
 
-    repaired_set = MapSet.new(repaired)
-    owned_set = MapSet.new(Enum.map(owned, &elem(&1, 0)))
-    foreign_set = MapSet.new(Enum.map(foreign, &elem(&1, 0)))
-    candidate_set = MapSet.union(owned_set, foreign_set)
+    attempted_set =
+      MapSet.new(attempted)
+      |> MapSet.intersection(MapSet.new(candidates))
 
-    # Ignore any background objects outside this test's planted keys.
-    repaired_set = MapSet.intersection(repaired_set, candidate_set)
+    assert attempted_set == MapSet.new(owned)
 
-    assert MapSet.subset?(repaired_set, owned_set)
-    assert MapSet.disjoint?(repaired_set, foreign_set)
-    assert repaired_set == owned_set
-
-    for {hkey, _} <- foreign do
-      refute_received {:store, ^hkey, _}
-    end
-
-    for hkey <- repaired_set do
-      assert_received {:store, ^hkey, _}
-    end
+    for hkey <- foreign, do: refute_received({:store, ^hkey, _})
+    for hkey <- attempted_set, do: assert_received({:store, ^hkey, _})
   end
 
   test "anti-entropy is cursor-batched and advances without reshuffling" do
     self = Diode.wallet()
-    # Only two peers so self is always in nearest-3 for every key
     peers = for _ <- 1..2, do: Wallet.new()
-    addresses = Enum.map(peers, &Wallet.address!/1)
-    assert :ok = Model.KademliaSql.sync_registry_nodes(addresses)
+    assert :ok = Model.KademliaSql.sync_registry_nodes(Enum.map(peers, &Wallet.address!/1))
 
     ring = [Node.new(self) | Enum.map(peers, &Node.new/1)]
     :ets.insert(:kademlia_network, {:ring, ring})
 
-    for i <- 1..25 do
-      hkey = <<i::256>>
-      put_local(hkey, data_value(i))
-    end
-
-    parent = self()
-
-    rpc_fun = fn _nodes, call ->
-      case call do
-        [:store, key, _value] ->
-          send(parent, {:store, key})
-          [["ok"]]
-
-        _ ->
-          [[]]
-      end
-    end
+    for i <- 1..25, do: put_local(<<i::256>>, data_value(i))
 
     online = Map.new(peers, fn w -> {Wallet.address!(w), self()} end)
+    rpc_fun = store_rpc(self(), :store)
 
     {first, cursor1} =
       KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online,
@@ -140,7 +111,7 @@ defmodule KademliaLightAntiEntropyTest do
 
     assert length(second) == 10
     assert cursor2 == <<20::256>>
-    refute Enum.any?(second, fn key -> key in first end)
+    refute Enum.any?(second, &(&1 in first))
 
     {third, cursor3} =
       KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online,
@@ -165,18 +136,16 @@ defmodule KademliaLightAntiEntropyTest do
 
     ring = [Node.new(self), Node.new(joiner) | Enum.map(others, &Node.new/1)]
     :ets.insert(:kademlia_network, {:ring, ring})
-
     joiner_node = Node.new(joiner)
 
     {for_joiner, not_for_joiner} =
       Enum.split_with(
         for i <- 1..80 do
           hkey = KademliaLight.hash(<<i + 100::256>>)
-          value = data_value(i)
-          put_local(hkey, value)
-          {hkey, value}
+          put_local(hkey, data_value(i))
+          hkey
         end,
-        fn {hkey, _} ->
+        fn hkey ->
           nearest = KademliaRing.nearest_n(ring, hkey, 3)
           Enum.any?(nearest, fn %Node{address: addr} -> addr == joiner_node.address end)
         end
@@ -186,42 +155,26 @@ defmodule KademliaLightAntiEntropyTest do
     assert not_for_joiner != []
 
     parent = self()
-
-    rpc_fun = fn nodes, call ->
-      case call do
-        [:store, key, _value] ->
-          send(parent, {:join_store, key, Enum.map(nodes, & &1.address)})
-          Enum.map(nodes, fn _ -> ["ok"] end)
-
-        _ ->
-          Enum.map(nodes, fn _ -> [] end)
-      end
-    end
-
     online = %{joiner_node.address => self()}
 
     pushed =
-      KademliaLight.join_catchup_with_rpc_test(joiner_node, rpc_fun, online, ring: ring)
+      KademliaLight.join_catchup_with_rpc_test(
+        joiner_node,
+        store_rpc(parent, :join_store),
+        online,
+        ring: ring
+      )
 
-    page_keys =
-      Model.KademliaSql.objects_page(nil, 100)
-      |> Enum.map(&elem(&1, 0))
-      |> MapSet.new()
+    # Join catch-up only scans the first objects_page batch.
+    page_keys = MapSet.new(Enum.map(Model.KademliaSql.objects_page(nil, 100), &elem(&1, 0)))
+    expected = MapSet.intersection(MapSet.new(for_joiner), page_keys)
 
-    expected =
-      for_joiner
-      |> Enum.map(&elem(&1, 0))
-      |> MapSet.new()
-      |> MapSet.intersection(page_keys)
+    assert MapSet.intersection(MapSet.new(pushed), page_keys) == expected
 
-    assert MapSet.new(pushed) |> MapSet.intersection(page_keys) == expected
+    addr = joiner_node.address
+    for hkey <- expected, do: assert_received({:join_store, ^hkey, [^addr]})
 
-    for hkey <- expected do
-      addr = joiner_node.address
-      assert_received {:join_store, ^hkey, [^addr]}
-    end
-
-    for {hkey, _} <- not_for_joiner, MapSet.member?(page_keys, hkey) do
+    for hkey <- not_for_joiner, MapSet.member?(page_keys, hkey) do
       refute_received {:join_store, ^hkey, _}
     end
   end
@@ -233,16 +186,11 @@ defmodule KademliaLightAntiEntropyTest do
     assert :ok = Model.KademliaSql.sync_registry_nodes([Wallet.address!(joiner)])
     ring = [Node.new(self), Node.new(joiner)]
     :ets.insert(:kademlia_network, {:ring, ring})
+    put_local(KademliaLight.hash(<<200::256>>), data_value(1))
 
-    hkey = KademliaLight.hash(<<200::256>>)
-    put_local(hkey, data_value(1))
+    rpc_fun = fn _nodes, _call -> flunk("should not RPC to offline peer") end
 
-    rpc_fun = fn _nodes, _call ->
-      flunk("should not RPC to offline peer")
-    end
-
-    assert [] ==
-             KademliaLight.join_catchup_with_rpc_test(Node.new(joiner), rpc_fun, %{})
+    assert [] == KademliaLight.join_catchup_with_rpc_test(Node.new(joiner), rpc_fun, %{})
   end
 
   test "anti-entropy skips store RPC when no replica peers are online" do
@@ -253,16 +201,14 @@ defmodule KademliaLightAntiEntropyTest do
     ring = [Node.new(self), Node.new(peer)]
     :ets.insert(:kademlia_network, {:ring, ring})
 
-    # Find a key where self is a rightful replica
-    {hkey, _value} =
+    hkey =
       Enum.find_value(1..80, fn i ->
         hkey = KademliaLight.hash(<<i + 300::256>>)
         nearest = KademliaRing.nearest_n(ring, hkey, 3)
 
         if Enum.any?(nearest, &KademliaRing.is_self/1) do
-          value = data_value(i)
-          put_local(hkey, value)
-          {hkey, value}
+          put_local(hkey, data_value(i))
+          hkey
         end
       end)
 
@@ -272,10 +218,9 @@ defmodule KademliaLightAntiEntropyTest do
       flunk("should not RPC when replica targets are offline")
     end
 
-    {repaired, _} =
+    {attempted, _} =
       KademliaLight.anti_entropy_with_rpc_test(rpc_fun, %{}, batch: 100, ring: ring)
 
-    # Self is responsible so key is selected, but repair finds no online remotes
-    assert hkey in repaired
+    assert hkey in attempted
   end
 end

--- a/test/kademlia_light_anti_entropy_test.exs
+++ b/test/kademlia_light_anti_entropy_test.exs
@@ -1,0 +1,281 @@
+# Diode Server
+# Copyright 2021-2026 Diode
+# Licensed under the Diode License, Version 1.1
+defmodule KademliaLightAntiEntropyTest do
+  use ExUnit.Case
+
+  alias KademliaLight.Node
+  alias DiodeClient.{Object, Wallet}
+
+  setup do
+    Model.CredSql.set_wallet(Wallet.new())
+    Model.KademliaSql.clear()
+    Model.KademliaSql.init()
+    :ok
+  end
+
+  defp data_value(block) do
+    Object.Data.new(block, "anti_entropy", "v#{block}", Wallet.privkey!(Wallet.new()))
+    |> Object.encode!()
+  end
+
+  defp put_local(hkey, value) do
+    Model.KademliaSql.put_object(hkey, value)
+  end
+
+  test "anti-entropy repairs only keys where self is in nearest-N" do
+    self = Diode.wallet()
+    peers = for _ <- 1..8, do: Wallet.new()
+    addresses = Enum.map(peers, &Wallet.address!/1)
+    assert :ok = Model.KademliaSql.sync_registry_nodes(addresses)
+
+    ring = [Node.new(self) | Enum.map(peers, &Node.new/1)]
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    candidates =
+      for i <- 1..80 do
+        hkey = KademliaLight.hash(<<i::256>>)
+        value = data_value(i)
+        put_local(hkey, value)
+        {hkey, value}
+      end
+
+    # Live GenServer may reload :ring after sync; pin again before classification/run.
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    {owned, foreign} =
+      Enum.split_with(candidates, fn {hkey, _} ->
+        nearest = KademliaRing.nearest_n(ring, hkey, 3)
+        Enum.any?(nearest, &KademliaRing.is_self/1)
+      end)
+
+    assert owned != []
+    assert foreign != []
+
+    parent = self()
+
+    rpc_fun = fn nodes, call ->
+      case call do
+        [:store, key, _value] ->
+          send(parent, {:store, key, Enum.map(nodes, & &1.address)})
+          Enum.map(nodes, fn _ -> ["ok"] end)
+
+        _ ->
+          Enum.map(nodes, fn _ -> [] end)
+      end
+    end
+
+    online = Map.new(peers, fn w -> {Wallet.address!(w), self()} end)
+
+    {repaired, _cursor} =
+      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online, batch: 100, ring: ring)
+
+    repaired_set = MapSet.new(repaired)
+    owned_set = MapSet.new(Enum.map(owned, &elem(&1, 0)))
+    foreign_set = MapSet.new(Enum.map(foreign, &elem(&1, 0)))
+    candidate_set = MapSet.union(owned_set, foreign_set)
+
+    # Ignore any background objects outside this test's planted keys.
+    repaired_set = MapSet.intersection(repaired_set, candidate_set)
+
+    assert MapSet.subset?(repaired_set, owned_set)
+    assert MapSet.disjoint?(repaired_set, foreign_set)
+    assert repaired_set == owned_set
+
+    for {hkey, _} <- foreign do
+      refute_received {:store, ^hkey, _}
+    end
+
+    for hkey <- repaired_set do
+      assert_received {:store, ^hkey, _}
+    end
+  end
+
+  test "anti-entropy is cursor-batched and advances without reshuffling" do
+    self = Diode.wallet()
+    # Only two peers so self is always in nearest-3 for every key
+    peers = for _ <- 1..2, do: Wallet.new()
+    addresses = Enum.map(peers, &Wallet.address!/1)
+    assert :ok = Model.KademliaSql.sync_registry_nodes(addresses)
+
+    ring = [Node.new(self) | Enum.map(peers, &Node.new/1)]
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    for i <- 1..25 do
+      hkey = <<i::256>>
+      put_local(hkey, data_value(i))
+    end
+
+    parent = self()
+
+    rpc_fun = fn _nodes, call ->
+      case call do
+        [:store, key, _value] ->
+          send(parent, {:store, key})
+          [["ok"]]
+
+        _ ->
+          [[]]
+      end
+    end
+
+    online = Map.new(peers, fn w -> {Wallet.address!(w), self()} end)
+
+    {first, cursor1} =
+      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online,
+        cursor: nil,
+        batch: 10,
+        ring: ring
+      )
+
+    assert length(first) == 10
+    assert cursor1 == <<10::256>>
+
+    {second, cursor2} =
+      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online,
+        cursor: cursor1,
+        batch: 10,
+        ring: ring
+      )
+
+    assert length(second) == 10
+    assert cursor2 == <<20::256>>
+    refute Enum.any?(second, fn key -> key in first end)
+
+    {third, cursor3} =
+      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, online,
+        cursor: cursor2,
+        batch: 10,
+        ring: ring
+      )
+
+    assert length(third) == 5
+    assert cursor3 == nil
+  end
+
+  test "join catch-up stores only keys where peer is in nearest-N" do
+    self = Diode.wallet()
+    joiner = Wallet.new()
+    others = for _ <- 1..7, do: Wallet.new()
+
+    assert :ok =
+             Model.KademliaSql.sync_registry_nodes([
+               Wallet.address!(joiner) | Enum.map(others, &Wallet.address!/1)
+             ])
+
+    ring = [Node.new(self), Node.new(joiner) | Enum.map(others, &Node.new/1)]
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    joiner_node = Node.new(joiner)
+
+    {for_joiner, not_for_joiner} =
+      Enum.split_with(
+        for i <- 1..80 do
+          hkey = KademliaLight.hash(<<i + 100::256>>)
+          value = data_value(i)
+          put_local(hkey, value)
+          {hkey, value}
+        end,
+        fn {hkey, _} ->
+          nearest = KademliaRing.nearest_n(ring, hkey, 3)
+          Enum.any?(nearest, fn %Node{address: addr} -> addr == joiner_node.address end)
+        end
+      )
+
+    assert for_joiner != []
+    assert not_for_joiner != []
+
+    parent = self()
+
+    rpc_fun = fn nodes, call ->
+      case call do
+        [:store, key, _value] ->
+          send(parent, {:join_store, key, Enum.map(nodes, & &1.address)})
+          Enum.map(nodes, fn _ -> ["ok"] end)
+
+        _ ->
+          Enum.map(nodes, fn _ -> [] end)
+      end
+    end
+
+    online = %{joiner_node.address => self()}
+
+    pushed =
+      KademliaLight.join_catchup_with_rpc_test(joiner_node, rpc_fun, online, ring: ring)
+
+    page_keys =
+      Model.KademliaSql.objects_page(nil, 100)
+      |> Enum.map(&elem(&1, 0))
+      |> MapSet.new()
+
+    expected =
+      for_joiner
+      |> Enum.map(&elem(&1, 0))
+      |> MapSet.new()
+      |> MapSet.intersection(page_keys)
+
+    assert MapSet.new(pushed) |> MapSet.intersection(page_keys) == expected
+
+    for hkey <- expected do
+      addr = joiner_node.address
+      assert_received {:join_store, ^hkey, [^addr]}
+    end
+
+    for {hkey, _} <- not_for_joiner, MapSet.member?(page_keys, hkey) do
+      refute_received {:join_store, ^hkey, _}
+    end
+  end
+
+  test "join catch-up skips offline peers" do
+    self = Diode.wallet()
+    joiner = Wallet.new()
+
+    assert :ok = Model.KademliaSql.sync_registry_nodes([Wallet.address!(joiner)])
+    ring = [Node.new(self), Node.new(joiner)]
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    hkey = KademliaLight.hash(<<200::256>>)
+    put_local(hkey, data_value(1))
+
+    rpc_fun = fn _nodes, _call ->
+      flunk("should not RPC to offline peer")
+    end
+
+    assert [] ==
+             KademliaLight.join_catchup_with_rpc_test(Node.new(joiner), rpc_fun, %{})
+  end
+
+  test "anti-entropy skips store RPC when no replica peers are online" do
+    self = Diode.wallet()
+    peer = Wallet.new()
+
+    assert :ok = Model.KademliaSql.sync_registry_nodes([Wallet.address!(peer)])
+    ring = [Node.new(self), Node.new(peer)]
+    :ets.insert(:kademlia_network, {:ring, ring})
+
+    # Find a key where self is a rightful replica
+    {hkey, _value} =
+      Enum.find_value(1..80, fn i ->
+        hkey = KademliaLight.hash(<<i + 300::256>>)
+        nearest = KademliaRing.nearest_n(ring, hkey, 3)
+
+        if Enum.any?(nearest, &KademliaRing.is_self/1) do
+          value = data_value(i)
+          put_local(hkey, value)
+          {hkey, value}
+        end
+      end)
+
+    assert hkey
+
+    rpc_fun = fn _nodes, _call ->
+      flunk("should not RPC when replica targets are offline")
+    end
+
+    {repaired, _} =
+      KademliaLight.anti_entropy_with_rpc_test(rpc_fun, %{}, batch: 100, ring: ring)
+
+    # Self is responsible so key is selected, but repair finds no online remotes
+    assert hkey in repaired
+  end
+end

--- a/test/model/kademliasql_test.exs
+++ b/test/model/kademliasql_test.exs
@@ -60,6 +60,51 @@ defmodule Model.KademliaSqlTest do
     assert meta.next_retry != nil
   end
 
+  test "objects_page orders by key and paginates after_key" do
+    values =
+      for i <- 1..5 do
+        key = <<i::256>>
+        value = Object.encode!(Diode.self())
+        Model.KademliaSql.put_object(key, value)
+        {key, value}
+      end
+
+    page1 = Model.KademliaSql.objects_page(nil, 2)
+    assert length(page1) == 2
+    assert Enum.map(page1, &elem(&1, 0)) == [<<1::256>>, <<2::256>>]
+
+    [{last_key, _} | _] = Enum.reverse(page1)
+    page2 = Model.KademliaSql.objects_page(last_key, 2)
+    assert Enum.map(page2, &elem(&1, 0)) == [<<3::256>>, <<4::256>>]
+
+    page3 = Model.KademliaSql.objects_page(<<4::256>>, 10)
+    assert Enum.map(page3, &elem(&1, 0)) == [<<5::256>>]
+
+    # Ensure values round-trip (BertInt-decoded binaries)
+    Enum.each(values, fn {key, value} ->
+      assert {^key, ^value} =
+               Enum.find(page1 ++ page2 ++ page3, fn {k, _} -> k == key end)
+    end)
+  end
+
+  test "objects_page excludes objects past stale silence deadline" do
+    fresh = <<10::256>>
+    stale = <<11::256>>
+    value = Object.encode!(Diode.self())
+
+    Model.KademliaSql.put_object(fresh, value)
+    Model.KademliaSql.put_object(stale, value)
+
+    Model.KademliaSql.query!(
+      "UPDATE p2p_objects SET stored_at = ?1 WHERE key = ?2",
+      [Model.KademliaSql.stale_silence_deadline() - 1, stale]
+    )
+
+    keys = Model.KademliaSql.objects_page(nil, 100) |> Enum.map(&elem(&1, 0))
+    assert fresh in keys
+    refute stale in keys
+  end
+
   defp registry_addresses() do
     Model.KademliaSql.query!("SELECT address FROM p2p_nodes WHERE on_chain = 1")
     |> Enum.map(&hd/1)

--- a/test/model/kademliasql_test.exs
+++ b/test/model/kademliasql_test.exs
@@ -61,30 +61,18 @@ defmodule Model.KademliaSqlTest do
   end
 
   test "objects_page orders by key and paginates after_key" do
-    values =
-      for i <- 1..5 do
-        key = <<i::256>>
-        value = Object.encode!(Diode.self())
-        Model.KademliaSql.put_object(key, value)
-        {key, value}
-      end
+    for i <- 1..5 do
+      Model.KademliaSql.put_object(<<i::256>>, Object.encode!(Diode.self()))
+    end
 
     page1 = Model.KademliaSql.objects_page(nil, 2)
-    assert length(page1) == 2
     assert Enum.map(page1, &elem(&1, 0)) == [<<1::256>>, <<2::256>>]
 
-    [{last_key, _} | _] = Enum.reverse(page1)
-    page2 = Model.KademliaSql.objects_page(last_key, 2)
+    page2 = Model.KademliaSql.objects_page(<<2::256>>, 2)
     assert Enum.map(page2, &elem(&1, 0)) == [<<3::256>>, <<4::256>>]
 
     page3 = Model.KademliaSql.objects_page(<<4::256>>, 10)
     assert Enum.map(page3, &elem(&1, 0)) == [<<5::256>>]
-
-    # Ensure values round-trip (BertInt-decoded binaries)
-    Enum.each(values, fn {key, value} ->
-      assert {^key, ^value} =
-               Enum.find(page1 ++ page2 ++ page3, fn {k, _} -> k == key end)
-    end)
   end
 
   test "objects_page excludes objects past stale silence deadline" do


### PR DESCRIPTION
## Summary
- Remove Chord-style `node_range` / stale redistribute scanning that re-ran forever for offline registry nodes and caused high CPU + log spam.
- Add cursor-batched nearest-N anti-entropy (periodic) and join catch-up on `stable_node`, with a single anti-entropy kick on registry membership removal.
- Add regression coverage for ownership filtering, cursor pagination, join catch-up, and `objects_page`.

## Test plan
- [x] `mix lint`
- [x] `mix test test/kademlia_light_anti_entropy_test.exs test/model/kademliasql_test.exs test/kademlia_light_quorum_test.exs`
- [ ] Confirm a previously churning node no longer floods `Redistributing ... stale objects` logs after deploy
- [ ] Spot-check that newly stable peers still receive replica stores (join catch-up) and finds still succeed under quorum


Made with [Cursor](https://cursor.com)