### PR TITLE
Reject Moonbeam transactions as immediate reverts

### DIFF
--- a/lib/remote_chain/edge.ex
+++ b/lib/remote_chain/edge.ex
@@ -116,10 +116,15 @@ defmodule RemoteChain.Edge do
         |> response()
 
       ["sendtransaction", payload] ->
-        case RemoteChain.RPC.send_raw_transaction(chain, Base16.encode(payload)) do
-          :already_known -> response("ok")
-          tx_hash when is_binary(tx_hash) -> response("ok")
-          {:error, error} -> error(error)
+        if RemoteChain.accepts_transactions?(chain) do
+          case RemoteChain.RPC.send_raw_transaction(chain, Base16.encode(payload)) do
+            :already_known -> response("ok")
+            tx_hash when is_binary(tx_hash) -> response("ok")
+            {:error, error} -> error(error)
+          end
+        else
+          # Same client-visible outcome as a simulated metatx revert.
+          error("transaction_rejected")
         end
 
       ["getmetanonce", block, address] ->
@@ -133,11 +138,15 @@ defmodule RemoteChain.Edge do
         |> response()
 
       ["sendmetatransaction", tx] ->
-        if CallPermitAdapter.should_forward_metatransaction?(chain) do
-          CallPermitAdapter.forward_metatransaction(chain, tx)
+        if not RemoteChain.accepts_transactions?(chain) do
+          error("transaction_rejected")
         else
-          {to, call, sender, min_gas_limit} = prepare_metatransaction(chain, Rlp.decode!(tx))
-          send_metatransaction(chain, to, call, sender, min_gas_limit)
+          if CallPermitAdapter.should_forward_metatransaction?(chain) do
+            CallPermitAdapter.forward_metatransaction(chain, tx)
+          else
+            {to, call, sender, min_gas_limit} = prepare_metatransaction(chain, Rlp.decode!(tx))
+            send_metatransaction(chain, to, call, sender, min_gas_limit)
+          end
         end
 
       ["rpc", "eth_call", params] when chain != Chains.OasisSapphire ->
@@ -186,30 +195,35 @@ defmodule RemoteChain.Edge do
   defp decode_rpc_params(params) when is_binary(params), do: Jason.decode(params)
 
   defp do_rpc(chain, method, params) do
-    if Network.Rpc.local_dio_method?(method) do
-      try do
-        case Network.Rpc.execute_dio(method, params, %{}) do
-          {_result, _code, error} when error != nil ->
-            %{"error" => error}
+    cond do
+      method == "eth_sendRawTransaction" and not RemoteChain.accepts_transactions?(chain) ->
+        %{"error" => %{"code" => -32000, "message" => "execution reverted"}}
 
-          {_result, code, _error} when code != 200 ->
-            %{"error" => %{"code" => code, "message" => "Request failed"}}
+      Network.Rpc.local_dio_method?(method) ->
+        try do
+          case Network.Rpc.execute_dio(method, params, %{}) do
+            {_result, _code, error} when error != nil ->
+              %{"error" => error}
 
-          {result, _code, _error} ->
-            actual =
-              case result do
-                {:raw, value} -> value
-                other -> other
-              end
+            {_result, code, _error} when code != 200 ->
+              %{"error" => %{"code" => code, "message" => "Request failed"}}
 
-            %{"result" => actual}
+            {result, _code, _error} ->
+              actual =
+                case result do
+                  {:raw, value} -> value
+                  other -> other
+                end
+
+              %{"result" => actual}
+          end
+        catch
+          :bad_request -> %{"error" => %{"code" => -32600, "message" => "Bad request"}}
+          :not_found -> %{"error" => %{"code" => -32602, "message" => "Not found"}}
         end
-      catch
-        :bad_request -> %{"error" => %{"code" => -32600, "message" => "Bad request"}}
-        :not_found -> %{"error" => %{"code" => -32602, "message" => "Not found"}}
-      end
-    else
-      RemoteChain.RPCCache.rpc(chain, method, params)
+
+      true ->
+        RemoteChain.RPCCache.rpc(chain, method, params)
     end
   end
 

--- a/lib/remote_chain/edge.ex
+++ b/lib/remote_chain/edge.ex
@@ -116,15 +116,11 @@ defmodule RemoteChain.Edge do
         |> response()
 
       ["sendtransaction", payload] ->
-        if RemoteChain.accepts_transactions?(chain) do
-          case RemoteChain.RPC.send_raw_transaction(chain, Base16.encode(payload)) do
-            :already_known -> response("ok")
-            tx_hash when is_binary(tx_hash) -> response("ok")
-            {:error, error} -> error(error)
-          end
-        else
-          # Same client-visible outcome as a simulated metatx revert.
-          error("transaction_rejected")
+        case RemoteChain.RPC.send_raw_transaction(chain, Base16.encode(payload)) do
+          :already_known -> response("ok")
+          tx_hash when is_binary(tx_hash) -> response("ok")
+          {:error, :transaction_rejected} -> error("transaction_rejected")
+          {:error, error} -> error(error)
         end
 
       ["getmetanonce", block, address] ->
@@ -138,15 +134,16 @@ defmodule RemoteChain.Edge do
         |> response()
 
       ["sendmetatransaction", tx] ->
-        if not RemoteChain.accepts_transactions?(chain) do
-          error("transaction_rejected")
-        else
-          if CallPermitAdapter.should_forward_metatransaction?(chain) do
+        cond do
+          not RemoteChain.accepts_transactions?(chain) ->
+            error("transaction_rejected")
+
+          CallPermitAdapter.should_forward_metatransaction?(chain) ->
             CallPermitAdapter.forward_metatransaction(chain, tx)
-          else
+
+          true ->
             {to, call, sender, min_gas_limit} = prepare_metatransaction(chain, Rlp.decode!(tx))
             send_metatransaction(chain, to, call, sender, min_gas_limit)
-          end
         end
 
       ["rpc", "eth_call", params] when chain != Chains.OasisSapphire ->
@@ -197,7 +194,7 @@ defmodule RemoteChain.Edge do
   defp do_rpc(chain, method, params) do
     cond do
       method == "eth_sendRawTransaction" and not RemoteChain.accepts_transactions?(chain) ->
-        %{"error" => %{"code" => -32000, "message" => "execution reverted"}}
+        %{"error" => RemoteChain.execution_reverted_rpc_error()}
 
       Network.Rpc.local_dio_method?(method) ->
         try do

--- a/lib/remote_chain/remote_chain.ex
+++ b/lib/remote_chain/remote_chain.ex
@@ -96,6 +96,11 @@ defmodule RemoteChain do
     chainimpl(chain) != Chains.Moonbeam
   end
 
+  @doc false
+  def execution_reverted_rpc_error do
+    %{"code" => -32000, "message" => "execution reverted"}
+  end
+
   for chain <- @all_chains do
     def chainimpl(unquote(chain.chain_id())), do: unquote(chain)
     def chainimpl(unquote(chain.chain_prefix())), do: unquote(chain)

--- a/lib/remote_chain/remote_chain.ex
+++ b/lib/remote_chain/remote_chain.ex
@@ -86,6 +86,16 @@ defmodule RemoteChain do
 
   def chains(), do: @chains
 
+  @doc """
+  Whether the node should attempt to submit transactions to this chain.
+
+  Moonbeam no longer accepts new transactions; treat submits as immediate
+  reverts instead of forwarding them to the network.
+  """
+  def accepts_transactions?(chain) do
+    chainimpl(chain) != Chains.Moonbeam
+  end
+
   for chain <- @all_chains do
     def chainimpl(unquote(chain.chain_id())), do: unquote(chain)
     def chainimpl(unquote(chain.chain_prefix())), do: unquote(chain)

--- a/lib/remote_chain/rpc.ex
+++ b/lib/remote_chain/rpc.ex
@@ -79,9 +79,7 @@ defmodule RemoteChain.RPC do
         {:error, error} -> {:error, error}
       end
     else
-      # Moonbeam (and any future non-accepting chain): reject like an EVM revert
-      # so callers treat the submit as failed without hitting the network.
-      {:error, %{"code" => -32000, "message" => "execution reverted"}}
+      {:error, :transaction_rejected}
     end
   end
 

--- a/lib/remote_chain/rpc.ex
+++ b/lib/remote_chain/rpc.ex
@@ -72,10 +72,16 @@ defmodule RemoteChain.RPC do
   end
 
   def send_raw_transaction(chain, tx) do
-    case rpc(chain, "eth_sendRawTransaction", [tx]) do
-      {:ok, tx_hash} -> tx_hash
-      {:error, %{"code" => -32603, "message" => "already known"}} -> :already_known
-      {:error, error} -> {:error, error}
+    if RemoteChain.accepts_transactions?(chain) do
+      case rpc(chain, "eth_sendRawTransaction", [tx]) do
+        {:ok, tx_hash} -> tx_hash
+        {:error, %{"code" => -32603, "message" => "already known"}} -> :already_known
+        {:error, error} -> {:error, error}
+      end
+    else
+      # Moonbeam (and any future non-accepting chain): reject like an EVM revert
+      # so callers treat the submit as failed without hitting the network.
+      {:error, %{"code" => -32000, "message" => "execution reverted"}}
     end
   end
 

--- a/test/remote_chain/edge_test.exs
+++ b/test/remote_chain/edge_test.exs
@@ -63,9 +63,8 @@ defmodule RemoteChain.EdgeTest do
                  %{}
                )
 
-      assert %{
-               "error" => %{"code" => -32000, "message" => "execution reverted"}
-             } = Jason.decode!(body)
+      assert %{"error" => error} = Jason.decode!(body)
+      assert error == RemoteChain.execution_reverted_rpc_error()
     end
   end
 end

--- a/test/remote_chain/edge_test.exs
+++ b/test/remote_chain/edge_test.exs
@@ -43,4 +43,29 @@ defmodule RemoteChain.EdgeTest do
                Edge.wallet_factory_address(Chains.OasisSapphire)
     end
   end
+
+  describe "Moonbeam transaction rejection" do
+    test "sendtransaction is rejected as if it reverted" do
+      assert ["error", "transaction_rejected"] =
+               Edge.handle_async_msg(Chains.Moonbeam, ["sendtransaction", <<1, 2, 3>>], %{})
+    end
+
+    test "sendmetatransaction is rejected as if it reverted" do
+      assert ["error", "transaction_rejected"] =
+               Edge.handle_async_msg(Chains.Moonbeam, ["sendmetatransaction", <<1, 2, 3>>], %{})
+    end
+
+    test "rpc eth_sendRawTransaction is rejected as execution reverted" do
+      assert ["response", body] =
+               Edge.handle_async_msg(
+                 Chains.Moonbeam,
+                 ["rpc", "eth_sendRawTransaction", ~s(["0xdead"])],
+                 %{}
+               )
+
+      assert %{
+               "error" => %{"code" => -32000, "message" => "execution reverted"}
+             } = Jason.decode!(body)
+    end
+  end
 end

--- a/test/remote_chain/remote_chain_test.exs
+++ b/test/remote_chain/remote_chain_test.exs
@@ -1,0 +1,21 @@
+# Diode Server
+# Copyright 2021-2026 Diode
+# Licensed under the Diode License, Version 1.1
+
+defmodule RemoteChainTest do
+  use ExUnit.Case, async: true
+
+  describe "accepts_transactions?/1" do
+    test "returns false for Moonbeam (module, chain id, and prefix)" do
+      refute RemoteChain.accepts_transactions?(Chains.Moonbeam)
+      refute RemoteChain.accepts_transactions?(Chains.Moonbeam.chain_id())
+      refute RemoteChain.accepts_transactions?("glmr")
+    end
+
+    test "returns true for other configured chains" do
+      assert RemoteChain.accepts_transactions?(Chains.Diode)
+      assert RemoteChain.accepts_transactions?(Chains.OasisSapphire)
+      assert RemoteChain.accepts_transactions?(Chains.Base)
+    end
+  end
+end

--- a/test/remote_chain/rpc_test.exs
+++ b/test/remote_chain/rpc_test.exs
@@ -46,17 +46,9 @@ defmodule RemoteChain.RPCTest do
   end
 
   describe "send_raw_transaction/2 Moonbeam rejection" do
-    test "rejects Moonbeam submits as execution reverted without contacting RPC" do
-      # Moonbeam no longer accepts transactions; the node must fail closed
-      # with the same shape as an EVM revert rather than hitting the network.
-      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
+    test "rejects Moonbeam submits as transaction_rejected without contacting RPC" do
+      assert {:error, :transaction_rejected} =
                RPC.send_raw_transaction(Chains.Moonbeam, "0xdead")
-
-      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
-               RPC.send_raw_transaction(Chains.Moonbeam.chain_id(), "0xdead")
-
-      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
-               RPC.send_raw_transaction("glmr", "0xdead")
     end
   end
 end

--- a/test/remote_chain/rpc_test.exs
+++ b/test/remote_chain/rpc_test.exs
@@ -44,4 +44,19 @@ defmodule RemoteChain.RPCTest do
       assert {:error, "weird"} = RPC.decode_rpc_response("weird")
     end
   end
+
+  describe "send_raw_transaction/2 Moonbeam rejection" do
+    test "rejects Moonbeam submits as execution reverted without contacting RPC" do
+      # Moonbeam no longer accepts transactions; the node must fail closed
+      # with the same shape as an EVM revert rather than hitting the network.
+      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
+               RPC.send_raw_transaction(Chains.Moonbeam, "0xdead")
+
+      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
+               RPC.send_raw_transaction(Chains.Moonbeam.chain_id(), "0xdead")
+
+      assert {:error, %{"code" => -32000, "message" => "execution reverted"}} =
+               RPC.send_raw_transaction("glmr", "0xdead")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Moonbeam no longer accepts new transactions; add `RemoteChain.accepts_transactions?/1` and fail closed for Moonbeam submits.
- Edge `sendtransaction` / `sendmetatransaction` return `transaction_rejected` (same as a simulated metatx revert); raw RPC submits return `execution reverted`.
- Covers `RemoteChain.RPC.send_raw_transaction/2` and Edge `rpc eth_sendRawTransaction` so internal and client paths never hit the network.

## Test plan
- [x] `DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/rpc_test.exs test/remote_chain/edge_test.exs test/remote_chain/remote_chain_test.exs`
- [x] `mix lint`
- [ ] Confirm a Moonbeam edge `sendmetatransaction` from a client receives `transaction_rejected`
- [ ] Confirm reads / other Moonbeam RPC methods still work


Made with [Cursor](https://cursor.com)