### PR TITLE
Reject chain providers whose latest block stopped advancing

### DIFF
--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -1,5 +1,20 @@
 defmodule RemoteChain.ChainList do
+  alias DiodeClient.Base16
   require Logger
+
+  # Provider verdicts are re-evaluated after this TTL so providers that stop
+  # following the chain (or recover from an outage) are reconsidered without a
+  # node restart. Expired verdicts keep being served while the re-test runs in
+  # the background, so callers never block on provider probes.
+  @test_cache_ttl_ms :timer.minutes(5)
+
+  # A provider counts as current if its latest block is at most this many
+  # expected block intervals old — the same cutoff WSConn uses to declare a
+  # live connection dead.
+  @max_stale_intervals 10
+
+  # How far ahead of the local clock a block timestamp may be (producer skew).
+  @max_future_skew_seconds 60
 
   def rpc_endpoints(chain, additional_endpoints \\ []) do
     endpoints(chain, additional_endpoints)[:rpc]
@@ -52,16 +67,62 @@ defmodule RemoteChain.ChainList do
   end
 
   def test?(url, chain) do
-    Globals.cache(
-      {__MODULE__, :test, url},
-      fn ->
-        Logger.info("Testing #{url} for #{chain}")
-        ret = do_test?(url, chain)
-        Logger.info("Tested #{url} for #{chain} and got #{ret}")
-        ret
-      end,
-      :infinity
-    )
+    key = {__MODULE__, :test, url}
+
+    case Globals.get(key) do
+      nil ->
+        refresh_test(url, chain)
+
+      {_value, tested_at} = entry ->
+        if expired?(tested_at) do
+          schedule_test_refresh(url, chain)
+        end
+
+        elem(entry, 0)
+    end
+  end
+
+  defp expired?(tested_at) do
+    System.monotonic_time(:millisecond) - tested_at > @test_cache_ttl_ms
+  end
+
+  defp refresh_test(url, chain) do
+    key = {__MODULE__, :test, url}
+
+    Globals.locked({__MODULE__, :test_lock, url}, fn ->
+      case Globals.get(key) do
+        nil ->
+          run_test(url, chain)
+
+        {value, _tested_at} ->
+          value
+      end
+    end)
+  end
+
+  defp schedule_test_refresh(url, chain) do
+    key = {__MODULE__, :test, url}
+
+    # Debounced so concurrent callers on the hot RPC path trigger at most one
+    # background re-probe per TTL, and never block on it. Skips the probe if
+    # another process already refreshed the verdict in the meantime.
+    Debouncer.immediate2({__MODULE__, :test_refresh, url}, fn ->
+      case Globals.get(key) do
+        {_value, tested_at} ->
+          if expired?(tested_at), do: run_test(url, chain)
+
+        nil ->
+          run_test(url, chain)
+      end
+    end)
+  end
+
+  defp run_test(url, chain) do
+    Logger.info("Testing #{url} for #{chain}")
+    ret = do_test?(url, chain)
+    Logger.info("Tested #{url} for #{chain} and got #{ret}")
+    Globals.put({__MODULE__, :test, url}, {ret, System.monotonic_time(:millisecond)})
+    ret
   end
 
   def do_test?("ws" <> _ = ws_endpoint, chain) do
@@ -82,7 +143,7 @@ defmodule RemoteChain.ChainList do
            ) do
         receive do
           {:response, _ws_url, %{"id" => 99, "result" => _chain_id}} ->
-            true
+            current_block?(pid, chain)
 
           {:DOWN, _ref, :process, ^pid, _reason} ->
             false
@@ -100,11 +161,66 @@ defmodule RemoteChain.ChainList do
     false
   end
 
-  def do_test?(url, _chain) do
-    case RemoteChain.HTTP.rpc(url, "eth_chainId", []) do
-      {:ok, _} -> true
-      {:error, _} -> false
+  def do_test?(url, chain) do
+    with {:ok, _chain_id} <- RemoteChain.HTTP.rpc(url, "eth_chainId", []),
+         {:ok, block} <- RemoteChain.HTTP.rpc(url, "eth_getBlockByNumber", ["latest", false]) do
+      block_current?(chain, block)
+    else
+      _ -> false
     end
+  end
+
+  defp current_block?(pid, chain) do
+    if :ok ==
+         RemoteChain.WSConn.send_request(
+           pid,
+           %{
+             "jsonrpc" => "2.0",
+             "id" => 100,
+             "method" => "eth_getBlockByNumber",
+             "params" => ["latest", false]
+           }
+           |> Poison.encode!(),
+           10_000
+         ) do
+      receive do
+        {:response, _ws_url, %{"id" => 100, "result" => block}} when is_map(block) ->
+          block_current?(chain, block)
+      after
+        3_000 ->
+          false
+      end
+    else
+      false
+    end
+  end
+
+  @doc """
+  Whether the provider's latest block is recent enough, i.e. the provider is
+  still following the chain head. Some providers (observed with Oasis Sapphire)
+  keep responding to requests while stuck on an old block, which makes them
+  unusable as block sources even though they pass an `eth_chainId` check.
+
+  A block counts as current if its timestamp is at most
+  `expected_block_intervall * 10` seconds old (the same cutoff `WSConn` uses
+  to declare a live connection dead), and not implausibly in the future.
+  """
+  def block_current?(chain, %{"timestamp" => timestamp}) when is_binary(timestamp) do
+    timestamp_current?(max_block_age_seconds(chain), Base16.decode_int(timestamp))
+  end
+
+  def block_current?(_chain, _block), do: false
+
+  @doc false
+  def timestamp_current?(max_age_seconds, block_timestamp)
+      when is_integer(max_age_seconds) and is_integer(block_timestamp) do
+    age = System.os_time(:second) - block_timestamp
+    age >= -@max_future_skew_seconds and age <= max_age_seconds
+  end
+
+  @doc false
+  def max_block_age_seconds(chain) do
+    RemoteChain.chainimpl(chain).expected_block_intervall() * @max_stale_intervals
   end
 
   @loaded_key {__MODULE__, :loaded}

--- a/test/remote_chain/chain_list_test.exs
+++ b/test/remote_chain/chain_list_test.exs
@@ -5,6 +5,77 @@ defmodule RemoteChain.ChainListTest do
   @other_chain_id 56
   @loaded_key {RemoteChain.ChainList, :loaded}
 
+  # Minimal JSON-RPC server standing in for a chain provider over HTTP.
+  defmodule MockChainRpcPlug do
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(conn, opts) do
+      {:ok, body, conn} = read_body(conn)
+      %{"id" => id, "method" => method} = Poison.decode!(body)
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, Poison.encode!(rpc_reply(id, method, opts)))
+    end
+
+    defp rpc_reply(id, "eth_chainId", opts) do
+      if opts[:chain_id_error] do
+        %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => -32000, "message" => "down"}}
+      else
+        %{"jsonrpc" => "2.0", "id" => id, "result" => "0x7a69"}
+      end
+    end
+
+    defp rpc_reply(id, "eth_getBlockByNumber", opts) do
+      %{
+        "jsonrpc" => "2.0",
+        "id" => id,
+        "result" => %{"number" => "0x1", "timestamp" => opts[:timestamp]}
+      }
+    end
+
+    defp rpc_reply(id, _method, _opts) do
+      %{"jsonrpc" => "2.0", "id" => id, "result" => nil}
+    end
+  end
+
+  # Minimal JSON-RPC server standing in for a chain provider over WebSocket.
+  # Answers the WSConn handshake (eth_subscribe, eth_blockNumber) plus the
+  # eth_chainId / eth_getBlockByNumber probes sent by ChainList.do_test?/2.
+  defmodule MockChainWsHandler do
+    @behaviour :cowboy_websocket
+
+    @impl true
+    def init(req, opts) do
+      {:cowboy_websocket, req, opts}
+    end
+
+    @impl true
+    def websocket_handle({:text, json}, opts) do
+      %{"id" => id, "method" => method} = Poison.decode!(json)
+
+      result =
+        case {id, method} do
+          {1, "eth_subscribe"} -> "0x1"
+          {2, "eth_blockNumber"} -> "0x10"
+          {99, "eth_chainId"} -> "0x7a69"
+          {100, "eth_getBlockByNumber"} -> %{"number" => "0x10", "timestamp" => opts[:timestamp]}
+          _ -> nil
+        end
+
+      reply = Poison.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => result})
+      {:reply, {:text, reply}, opts}
+    end
+
+    @impl true
+    def websocket_handle(_frame, opts), do: {:ok, opts}
+
+    @impl true
+    def websocket_info(_msg, opts), do: {:ok, opts}
+  end
+
   setup do
     on_exit(&clear_chain_cache/0)
     clear_chain_cache()
@@ -82,6 +153,143 @@ defmodule RemoteChain.ChainListTest do
 
     assert Globals.get(key)["name"] == "updated"
     assert Globals.get(uncached_key) == nil
+  end
+
+  describe "block_current?/2" do
+    test "accepts a block with a fresh timestamp" do
+      assert RemoteChain.ChainList.block_current?(Chains.Anvil, %{
+               "timestamp" => hex_timestamp(System.os_time(:second))
+             })
+    end
+
+    test "rejects a provider whose latest block stopped updating" do
+      stale = System.os_time(:second) - 24 * 3600
+
+      refute RemoteChain.ChainList.block_current?(Chains.Anvil, %{
+               "timestamp" => hex_timestamp(stale)
+             })
+    end
+
+    test "rejects blocks without a decodable timestamp" do
+      refute RemoteChain.ChainList.block_current?(Chains.Anvil, %{})
+      refute RemoteChain.ChainList.block_current?(Chains.Anvil, nil)
+    end
+
+    test "max_block_age_seconds scales with the chain's block interval" do
+      assert RemoteChain.ChainList.max_block_age_seconds(Chains.Anvil) == 150
+      assert RemoteChain.ChainList.max_block_age_seconds(Chains.OasisSapphire) == 60
+    end
+  end
+
+  describe "timestamp_current?/2" do
+    test "accepts blocks within max age, rejects older ones" do
+      now = System.os_time(:second)
+
+      assert RemoteChain.ChainList.timestamp_current?(150, now)
+      assert RemoteChain.ChainList.timestamp_current?(150, now - 150)
+      refute RemoteChain.ChainList.timestamp_current?(150, now - 151)
+    end
+
+    test "accepts limited future clock skew, rejects beyond it" do
+      now = System.os_time(:second)
+
+      assert RemoteChain.ChainList.timestamp_current?(150, now + 60)
+      refute RemoteChain.ChainList.timestamp_current?(150, now + 61)
+    end
+  end
+
+  describe "do_test?/2 HTTP providers" do
+    test "accepts a provider serving current blocks" do
+      with_http_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
+        assert RemoteChain.ChainList.do_test?(url, Chains.Anvil)
+      end)
+    end
+
+    test "rejects a provider that answers eth_chainId but stopped providing new blocks" do
+      # Regression: some Oasis providers keep responding to RPC while stuck on
+      # an old block height. eth_chainId alone used to pass the filter.
+      with_http_mock([timestamp: hex_timestamp(System.os_time(:second) - 24 * 3600)], fn url ->
+        refute RemoteChain.ChainList.do_test?(url, Chains.Anvil)
+      end)
+    end
+
+    test "rejects a provider that fails eth_chainId" do
+      with_http_mock([chain_id_error: true], fn url ->
+        refute RemoteChain.ChainList.do_test?(url, Chains.Anvil)
+      end)
+    end
+  end
+
+  describe "do_test?/2 WS providers" do
+    test "accepts a provider serving current blocks" do
+      with_ws_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
+        assert RemoteChain.ChainList.do_test?(url, Chains.Anvil)
+      end)
+    end
+
+    test "rejects a provider that answers eth_chainId but stopped providing new blocks" do
+      with_ws_mock([timestamp: hex_timestamp(System.os_time(:second) - 24 * 3600)], fn url ->
+        refute RemoteChain.ChainList.do_test?(url, Chains.Anvil)
+      end)
+    end
+  end
+
+  describe "test?/2 caching" do
+    test "caches the verdict and does not re-probe within the TTL" do
+      with_http_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
+        assert RemoteChain.ChainList.test?(url, Chains.Anvil) == true
+
+        # Verdict is stored with a monotonic probe timestamp.
+        assert {true, tested_at} = Globals.get({RemoteChain.ChainList, :test, url})
+        assert is_integer(tested_at)
+
+        # Stop the mock: a cached verdict must be served without probing.
+        Plug.Cowboy.shutdown(mock_ref())
+        assert RemoteChain.ChainList.test?(url, Chains.Anvil) == true
+      end)
+    end
+
+    test "rejects a stale provider through the cached test? entry" do
+      with_http_mock([timestamp: hex_timestamp(System.os_time(:second) - 24 * 3600)], fn url ->
+        assert RemoteChain.ChainList.test?(url, Chains.Anvil) == false
+        assert {false, _tested_at} = Globals.get({RemoteChain.ChainList, :test, url})
+      end)
+    end
+  end
+
+  defp mock_ref(), do: {__MODULE__, :current_mock}
+
+  defp hex_timestamp(seconds), do: "0x" <> Integer.to_string(seconds, 16)
+
+  defp with_http_mock(opts, fun) do
+    {:ok, _} = Application.ensure_all_started(:plug_cowboy)
+    # Needed for DIODE_MINIMAL_TEST runs where the app (and its hackney HTTP
+    # client) is not started.
+    {:ok, _} = Application.ensure_all_started(:httpoison)
+    ref = mock_ref()
+
+    {:ok, _pid} = Plug.Cowboy.http(MockChainRpcPlug, opts, port: 0, ref: ref)
+
+    try do
+      fun.("http://127.0.0.1:#{:ranch.get_port(ref)}")
+    after
+      Plug.Cowboy.shutdown(ref)
+    end
+  end
+
+  defp with_ws_mock(opts, fun) do
+    {:ok, _} = Application.ensure_all_started(:cowboy)
+    ref = mock_ref()
+
+    dispatch = :cowboy_router.compile([{:_, [{:_, MockChainWsHandler, opts}]}])
+
+    {:ok, _pid} = :cowboy.start_clear(ref, [port: 0], %{env: %{dispatch: dispatch}})
+
+    try do
+      fun.("ws://127.0.0.1:#{:ranch.get_port(ref)}")
+    after
+      :cowboy.stop_listener(ref)
+    end
   end
 
   defp cache_key(chain_id), do: {RemoteChain.ChainList, chain_id}


### PR DESCRIPTION
## Summary

Some chain providers (observed on Oasis Sapphire) keep answering RPC requests while stuck on an old block. Since `ChainList.test?/2` only required a successful `eth_chainId` response, these frozen providers were admitted as block sources even though they no longer follow the chain head.

This PR adds a block-currency check and keeps provider verdicts fresh:

- After `eth_chainId`, HTTP and WS provider probes now also call `eth_getBlockByNumber("latest", false)` and require the block timestamp to be current (`block_current?/2`).
- "Current" means the block timestamp is at most `expected_block_intervall * 10` seconds old (the same cutoff `WSConn` uses to declare a live connection dead) and not more than 60 seconds ahead of the local clock (producer skew).
- Provider verdicts are re-evaluated after a 5-minute TTL. Expired verdicts keep being served while the re-test runs in the background (debounced), so the hot RPC path never blocks on provider probes and frozen or recovered providers are reconsidered without a node restart.

## Changes

- `lib/remote_chain/chain_list.ex` — block-currency probe for HTTP and WS providers; serve-stale/refresh-in-background verdict cache with TTL.
- `test/remote_chain/chain_list_test.exs` — mock HTTP (Plug) and WS (cowboy) chain providers; regression tests for `block_current?/2`, `timestamp_current?/2`, `max_block_age_seconds/1`, `do_test?/2` filtering stale/broken providers over both transports, and `test?/2` caching behavior.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix lint`
- [x] `DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/chain_list_test.exs`
- [x] `mix test test/remote_chain/ --seed 0`
- [ ] Observe on staging/mainnet that frozen Oasis providers are no longer selected as block sources

Made with [Cursor](https://cursor.com)