### PR TITLE
Exclude stale fallback providers from NodeProxy block consensus

### DIFF
--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -26,6 +26,25 @@ defmodule RemoteChain.ChainList do
     |> check_endpoints(chain)
   end
 
+  @doc """
+  WebSocket endpoints that are currently considered live for the given
+  chain. Filters `ws_endpoints/2` plus the supplied `additional_endpoints`
+  through `test?/2`, so providers that fail the staleness probe
+  (eth_chainId + eth_getBlockByNumber) are excluded.
+
+  Unlike `ws_endpoints/2`, this is meant to be called repeatedly on the
+  NodeProxy refill path: a provider that was healthy at startup but has
+  since gone stale gets a fresh probe within the 5-minute TTL and drops
+  out of the pool automatically.
+  """
+  def live_ws_endpoints(chain, additional_endpoints \\ []) do
+    chain_urls = ws_endpoints(chain) || []
+
+    (chain_urls ++ additional_endpoints)
+    |> Enum.uniq()
+    |> Enum.filter(fn url -> test?(url, chain) end)
+  end
+
   defp check_endpoints(endpoints, chain) do
     if endpoints == nil or endpoints == [] do
       Logger.error("No endpoints found for chain #{chain}")

--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -8,11 +8,6 @@ defmodule RemoteChain.ChainList do
   # the background, so callers never block on provider probes.
   @test_cache_ttl_ms :timer.minutes(5)
 
-  # A provider counts as current if its latest block is at most this many
-  # expected block intervals old — the same cutoff WSConn uses to declare a
-  # live connection dead.
-  @max_stale_intervals 10
-
   # How far ahead of the local clock a block timestamp may be (producer skew).
   @max_future_skew_seconds 60
 
@@ -21,21 +16,33 @@ defmodule RemoteChain.ChainList do
     |> check_endpoints(chain)
   end
 
+  @doc """
+  WebSocket endpoints for `chain`, optionally extended with caller-supplied
+  URLs. Returns only endpoints that pass the staleness probe.
+
+  Callers that supply their own fallback URLs (e.g. `NodeProxy`) should
+  prefer `live_ws_endpoints/2` instead — `ws_endpoints/2` does not re-test
+  the additional URLs on every call, so a permanently stale fallback would
+  be re-attached after every eviction. See `live_ws_endpoints/2`.
+  """
   def ws_endpoints(chain, additional_endpoints \\ []) do
     endpoints(chain, additional_endpoints)[:ws]
     |> check_endpoints(chain)
   end
 
   @doc """
-  WebSocket endpoints that are currently considered live for the given
-  chain, including the supplied `additional_endpoints` (typically the
-  configured fallback URLs).
+  WebSocket endpoints that are currently considered live for `chain`,
+  including the supplied `additional_endpoints` (typically the configured
+  fallback URLs).
 
-  `ws_endpoints/2` already runs every chainlist URL through `test?/2`,
-  so the chain URLs need no further filtering. The additional URLs do
-  not, so they are tested here. Used by `NodeProxy.ensure_connections/1`
-  to keep permanently stale fallback URLs (e.g. simplystaking.xyz on
-  us1) from being re-attached.
+  `ws_endpoints/2` already runs every chainlist URL through `test?/2`, so
+  the chain URLs need no further filtering; this function re-tests only the
+  `additional_endpoints`. A `ws_endpoints/2` that returns `nil` (chain id
+  not in the chainlist) is treated as "no chain URLs, only additional" so
+  this function still has well-defined behaviour for unknown chains.
+
+  Used by `NodeProxy.ensure_connections/1` to keep permanently stale
+  fallback URLs (e.g. simplystaking.xyz on us1) from being re-attached.
   """
   def live_ws_endpoints(chain, additional_endpoints \\ []) do
     chain_urls = ws_endpoints(chain) || []
@@ -218,12 +225,20 @@ defmodule RemoteChain.ChainList do
   keep responding to requests while stuck on an old block, which makes them
   unusable as block sources even though they pass an `eth_chainId` check.
 
-  A block counts as current if its timestamp is at most
-  `expected_block_intervall * 10` seconds old (the same cutoff `WSConn` uses
-  to declare a live connection dead), and not implausibly in the future.
+  The age cutoff is shared with `RemoteChain.WSConn.stale_at?/3` (the same
+  `@stale_threshold_intervals` constant), so an endpoint that passes here
+  will not be flagged as stale by the WSConn's `:ping` handler. Future clock
+  skew is bounded separately by `@max_future_skew_seconds` because the
+  staleness predicate only checks how stale a `lastblock_at` is — never how
+  far in the future it sits.
   """
   def block_current?(chain, %{"timestamp" => timestamp}) when is_binary(timestamp) do
-    timestamp_current?(max_block_age_seconds(chain), Base16.decode_int(timestamp))
+    block_ts = Base16.decode_int(timestamp)
+    now = System.os_time(:second)
+    age = now - block_ts
+
+    age >= -@max_future_skew_seconds and
+      not RemoteChain.WSConn.stale_at?(block_age_to_lastblock_at(now, age), chain)
   end
 
   def block_current?(_chain, _block), do: false
@@ -237,7 +252,15 @@ defmodule RemoteChain.ChainList do
 
   @doc false
   def max_block_age_seconds(chain) do
-    RemoteChain.chainimpl(chain).expected_block_intervall() * @max_stale_intervals
+    RemoteChain.chainimpl(chain).expected_block_intervall() *
+      RemoteChain.WSConn.stale_threshold_intervals()
+  end
+
+  # Reconstruct a synthetic `lastblock_at` so we can reuse `WSConn.stale_at?/3`
+  # for the staleness check. The predicate only looks at `DateTime.diff/3`,
+  # so any reference point with the right age is equivalent.
+  defp block_age_to_lastblock_at(now, age) do
+    DateTime.from_unix!(now - age)
   end
 
   @loaded_key {__MODULE__, :loaded}

--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -28,21 +28,19 @@ defmodule RemoteChain.ChainList do
 
   @doc """
   WebSocket endpoints that are currently considered live for the given
-  chain. Filters `ws_endpoints/2` plus the supplied `additional_endpoints`
-  through `test?/2`, so providers that fail the staleness probe
-  (eth_chainId + eth_getBlockByNumber) are excluded.
+  chain, including the supplied `additional_endpoints` (typically the
+  configured fallback URLs).
 
-  Unlike `ws_endpoints/2`, this is meant to be called repeatedly on the
-  NodeProxy refill path: a provider that was healthy at startup but has
-  since gone stale gets a fresh probe within the 5-minute TTL and drops
-  out of the pool automatically.
+  `ws_endpoints/2` already runs every chainlist URL through `test?/2`,
+  so the chain URLs need no further filtering. The additional URLs do
+  not, so they are tested here. Used by `NodeProxy.ensure_connections/1`
+  to keep permanently stale fallback URLs (e.g. simplystaking.xyz on
+  us1) from being re-attached.
   """
   def live_ws_endpoints(chain, additional_endpoints \\ []) do
     chain_urls = ws_endpoints(chain) || []
-
-    (chain_urls ++ additional_endpoints)
-    |> Enum.uniq()
-    |> Enum.filter(fn url -> test?(url, chain) end)
+    extra_live = Enum.filter(additional_endpoints, fn url -> test?(url, chain) end)
+    Enum.uniq(chain_urls ++ extra_live)
   end
 
   defp check_endpoints(endpoints, chain) do

--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -183,7 +183,8 @@ defmodule RemoteChain.NodeProxy do
           lastblocks: lastblocks,
           subscriptions: subs,
           lastblock: lastblock,
-          fallback: fallback
+          fallback: fallback,
+          fallback_url: fallback_url
         }
       ) do
     now = DateTime.utc_now()
@@ -197,7 +198,16 @@ defmodule RemoteChain.NodeProxy do
         block >= block_number and not RemoteChain.WSConn.stale_at?(lastblock_at, chain)
       end)
 
-    fallback_live? = fallback != nil and not RemoteChain.WSConn.stale?(fallback, chain)
+    # Prefer the cached `lastblocks` entry so the consensus path never makes
+    # a `:sys.get_state` call to the fallback pid. Fall back to the WSConn's
+    # own `lastblock_at` only when the fallback has never reported a block.
+    fallback_live? =
+      fallback != nil and
+        case Map.get(lastblocks, fallback_url) do
+          {_block, lastblock_at} -> not RemoteChain.WSConn.stale_at?(lastblock_at, chain)
+          nil -> not RemoteChain.WSConn.stale?(fallback, chain)
+        end
+
     security_level = if fallback_live?, do: @security_level + 1, else: @security_level
 
     block_number =
@@ -451,7 +461,9 @@ defmodule RemoteChain.NodeProxy do
     # even though the chain config still lists fallback URLs. Schedule a
     # refill so the next fallback URL (or none, if all are stale) takes
     # its place.
-    if fallback != nil and (state.fallback == nil or state.fallback_url == nil) do
+    removed_fallback? = fallback != nil and state.fallback == nil
+
+    if removed_fallback? do
       schedule_ensure_connections(state, 0)
     else
       state

--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -14,6 +14,14 @@ defmodule RemoteChain.NodeProxy do
   @rate_limit_reconnect_ms 15_000
   @security_level 1
 
+  # A WSConn that has gone this many expected block intervals without a new
+  # block is forcibly evicted, even though the socket itself is still alive.
+  # Two consecutive ping cycles (each 2 * expected_block_intervall seconds) is
+  # the upper bound: WSConn's own :ping handler closes a connection at 10 *
+  # expected_block_intervall, so we keep it in the pool for one cycle longer
+  # in case it recovers, then evict + ask ChainList to re-test the URL.
+  @stale_eviction_intervals 20
+
   defstruct [
     :chain,
     connections: %{},
@@ -178,11 +186,22 @@ defmodule RemoteChain.NodeProxy do
           fallback: fallback
         }
       ) do
-    lastblocks = Map.put(lastblocks, ws_url, block_number)
-    security_level = if fallback != nil, do: @security_level + 1, else: @security_level
+    now = DateTime.utc_now()
+    lastblocks = Map.put(lastblocks, ws_url, {block_number, now})
+
+    # A provider that has been silent for more than the staleness cutoff
+    # contributes zero votes to the quorum. Otherwise a single frozen
+    # fallback would block every block advance (the us1/Oasis incident).
+    live_voter_count =
+      Enum.count(lastblocks, fn {_url, {block, lastblock_at}} ->
+        block >= block_number and not stale_entry?(chain, lastblock_at)
+      end)
+
+    fallback_live? = fallback != nil and live_fallback?(chain, state)
+    security_level = if fallback_live?, do: @security_level + 1, else: @security_level
 
     block_number =
-      if Enum.count(lastblocks, fn {_, block} -> block >= block_number end) >= security_level do
+      if live_voter_count >= security_level do
         max(block_number, lastblock)
       else
         lastblock
@@ -391,29 +410,79 @@ defmodule RemoteChain.NodeProxy do
     }
   end
 
-  defp prune_stale_connections(
-         state = %NodeProxy{
-           connections: connections,
-           fallback: fallback,
-           fallback_url: fallback_url
-         }
-       ) do
+  @doc false
+  def prune_stale_connections(
+        state = %NodeProxy{
+          chain: chain,
+          connections: connections,
+          fallback: fallback,
+          fallback_url: fallback_url
+        }
+      ) do
     pool =
       if fallback_url && fallback,
         do: Map.put(connections, fallback_url, fallback),
         else: connections
 
-    Enum.reduce(pool, state, fn {url, pid}, state ->
-      if RemoteChain.WSConn.handshake_stale?(pid) do
-        Logger.warning(
-          "Evicting stale WSConn #{inspect(pid)} for #{inspect(state.chain)} [#{url}]"
-        )
+    state =
+      Enum.reduce(pool, state, fn {url, pid}, state ->
+        cond do
+          RemoteChain.WSConn.handshake_stale?(pid) ->
+            Logger.warning(
+              "Evicting handshake-stale WSConn #{inspect(pid)} for #{inspect(state.chain)} [#{url}]"
+            )
 
-        close_and_remove(state, pid)
-      else
-        state
-      end
-    end)
+            close_and_remove(state, pid)
+
+          data_stale?(state, chain, url) ->
+            Logger.warning(
+              "Evicting data-stale WSConn #{inspect(pid)} for #{inspect(state.chain)} [#{url}] " <>
+                "(no new blocks for >#{@stale_eviction_intervals} block intervals)"
+            )
+
+            close_and_remove(state, pid)
+
+          true ->
+            state
+        end
+      end)
+
+    # If we removed the fallback, the pool is now operating without one
+    # even though the chain config still lists fallback URLs. Schedule a
+    # refill so the next fallback URL (or none, if all are stale) takes
+    # its place.
+    if fallback != nil and not has_fallback?(state) do
+      schedule_ensure_connections(state, 0)
+    else
+      state
+    end
+  end
+
+  defp data_stale?(%NodeProxy{lastblocks: lastblocks}, chain, url) do
+    case Map.get(lastblocks, url) do
+      {_block, lastblock_at} ->
+        age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
+        age > chain.expected_block_intervall() * @stale_eviction_intervals
+
+      nil ->
+        # Never received a block from this provider; rely on WSConn's own
+        # `lastblock_at` (which is initialized to `started_at` and updated
+        # by `new_block`).
+        false
+    end
+  end
+
+  defp has_fallback?(%NodeProxy{fallback: fallback, fallback_url: fallback_url}) do
+    fallback != nil and fallback_url != nil
+  end
+
+  defp stale_entry?(chain, lastblock_at) do
+    age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
+    age > chain.expected_block_intervall() * 10
+  end
+
+  defp live_fallback?(chain, %{fallback: fallback}) do
+    fallback != nil and not RemoteChain.WSConn.stale?(fallback, chain)
   end
 
   defp close_and_remove(state, pid) do
@@ -492,10 +561,17 @@ defmodule RemoteChain.NodeProxy do
   defp ensure_connections(state = %NodeProxy{chain: chain}) do
     state = prune_stale_connections(state)
     %NodeProxy{connections: connections, fallback: fallback} = state
-    urls = MapSet.new(RemoteChain.ws_endpoints(chain))
+
+    # Apply `live_ws_endpoints/1` to BOTH the primary list and the configured
+    # fallback URLs. Without filtering fallback URLs, a permanently stale
+    # WS-only fallback (e.g. the simplystaking.xyz endpoint on us1) would be
+    # re-attached after every eviction and silently freeze the published
+    # block number forever.
+    fallback_candidates = RemoteChain.ws_fallback_endpoints(chain)
+    urls = MapSet.new(RemoteChain.ChainList.live_ws_endpoints(chain, fallback_candidates))
     existing = MapSet.new(Map.keys(connections))
     new_urls = MapSet.difference(urls, existing) |> Enum.to_list() |> Enum.shuffle()
-    fallback_url = List.first(Enum.shuffle(RemoteChain.ws_fallback_endpoints(chain)) ++ new_urls)
+    fallback_url = List.first(Enum.shuffle(fallback_candidates) ++ new_urls)
 
     cond do
       map_size(connections) < @security_level ->

--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -194,10 +194,10 @@ defmodule RemoteChain.NodeProxy do
     # fallback would block every block advance (the us1/Oasis incident).
     live_voter_count =
       Enum.count(lastblocks, fn {_url, {block, lastblock_at}} ->
-        block >= block_number and not stale_entry?(chain, lastblock_at)
+        block >= block_number and not RemoteChain.WSConn.stale_at?(lastblock_at, chain)
       end)
 
-    fallback_live? = fallback != nil and live_fallback?(chain, state)
+    fallback_live? = fallback != nil and not RemoteChain.WSConn.stale?(fallback, chain)
     security_level = if fallback_live?, do: @security_level + 1, else: @security_level
 
     block_number =
@@ -434,7 +434,7 @@ defmodule RemoteChain.NodeProxy do
 
             close_and_remove(state, pid)
 
-          data_stale?(state, chain, url) ->
+          data_stale?(state, chain, url, pid) ->
             Logger.warning(
               "Evicting data-stale WSConn #{inspect(pid)} for #{inspect(state.chain)} [#{url}] " <>
                 "(no new blocks for >#{@stale_eviction_intervals} block intervals)"
@@ -451,38 +451,27 @@ defmodule RemoteChain.NodeProxy do
     # even though the chain config still lists fallback URLs. Schedule a
     # refill so the next fallback URL (or none, if all are stale) takes
     # its place.
-    if fallback != nil and not has_fallback?(state) do
+    if fallback != nil and (state.fallback == nil or state.fallback_url == nil) do
       schedule_ensure_connections(state, 0)
     else
       state
     end
   end
 
-  defp data_stale?(%NodeProxy{lastblocks: lastblocks}, chain, url) do
-    case Map.get(lastblocks, url) do
-      {_block, lastblock_at} ->
-        age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
-        age > chain.expected_block_intervall() * @stale_eviction_intervals
+  # Whether `url` is associated with a WSConn that has been silent for
+  # longer than `@stale_eviction_intervals` block intervals. Uses the
+  # cached `lastblocks` entry when present (more accurate than
+  # WSConn's `lastblock_at`, which is the connection's last frame), and
+  # falls back to the WSConn's own `lastblock_at` via `lastblock_at/1`
+  # so a never-blocked connection is still evicted after the cutoff.
+  defp data_stale?(%NodeProxy{lastblocks: lastblocks}, chain, url, pid) do
+    lastblock_at =
+      case Map.get(lastblocks, url) do
+        {_block, ts} -> ts
+        nil -> RemoteChain.WSConn.lastblock_at(pid)
+      end
 
-      nil ->
-        # Never received a block from this provider; rely on WSConn's own
-        # `lastblock_at` (which is initialized to `started_at` and updated
-        # by `new_block`).
-        false
-    end
-  end
-
-  defp has_fallback?(%NodeProxy{fallback: fallback, fallback_url: fallback_url}) do
-    fallback != nil and fallback_url != nil
-  end
-
-  defp stale_entry?(chain, lastblock_at) do
-    age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
-    age > chain.expected_block_intervall() * 10
-  end
-
-  defp live_fallback?(chain, %{fallback: fallback}) do
-    fallback != nil and not RemoteChain.WSConn.stale?(fallback, chain)
+    RemoteChain.WSConn.stale_at?(lastblock_at, chain, @stale_eviction_intervals)
   end
 
   defp close_and_remove(state, pid) do

--- a/lib/remote_chain/ws_conn.ex
+++ b/lib/remote_chain/ws_conn.ex
@@ -25,6 +25,39 @@ defmodule RemoteChain.WSConn do
   def connection_timeout_ms(), do: @connection_timeout_ms
   def handshake_timeout_ms(), do: @connection_timeout_ms
 
+  # A connection is considered stale (and excluded from the block-number
+  # consensus) once its last observed block is older than this many expected
+  # block intervals. Matches the cutoff the `:ping` handler uses to declare a
+  # live connection dead on the same chain.
+  @stale_threshold_intervals 10
+
+  @doc """
+  Whether the WSConn has stopped receiving block updates even though the
+  underlying socket is still alive.
+
+  A connection is stale if its last observed block is older than
+  `chain.expected_block_intervall() * 10` seconds, the same cutoff the
+  `:ping` handler uses to declare a live connection dead. Used by
+  `NodeProxy` to exclude frozen providers from the block-number consensus
+  while keeping the connection in the pool (so it can recover without a
+  restart).
+
+  Returns `false` for processes that are not `WSConn` instances or that
+  cannot be inspected (dead, handshaking, mid-`sys.get_state` call).
+  """
+  def stale?(pid, chain) when is_pid(pid) do
+    case try_get_state(pid) do
+      %__MODULE__{lastblock_at: lastblock_at} when not is_nil(lastblock_at) ->
+        age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
+        age > chain.expected_block_intervall() * @stale_threshold_intervals
+
+      _ ->
+        false
+    end
+  end
+
+  def stale?(_other, _chain), do: false
+
   def start(owner, chain, ws_url) do
     state = %__MODULE__{
       owner: owner,

--- a/lib/remote_chain/ws_conn.ex
+++ b/lib/remote_chain/ws_conn.ex
@@ -27,33 +27,57 @@ defmodule RemoteChain.WSConn do
 
   # A connection is considered stale (and excluded from the block-number
   # consensus) once its last observed block is older than this many expected
-  # block intervals. Matches the cutoff the `:ping` handler uses to declare a
-  # live connection dead on the same chain.
+  # block intervals. Single source of truth for the staleness threshold used
+  # by `stale?/2`, the `:ping` close handler, and `NodeProxy`'s staleness-
+  # aware consensus.
   @stale_threshold_intervals 10
+
+  @doc """
+  Whether `lastblock_at` is older than the staleness cutoff for `chain`.
+
+  The default cutoff is `chain.expected_block_intervall() * #{@stale_threshold_intervals}`
+  seconds. `intervals` overrides the multiplier — used by `NodeProxy` for
+  its eviction pass (two ping cycles, `@stale_eviction_intervals`).
+
+  This is the single threshold shared by `stale?/2` (pid-based), the
+  `:ping` close handler, and `NodeProxy`'s consensus and eviction logic.
+  """
+  def stale_at?(lastblock_at, chain, intervals \\ @stale_threshold_intervals) do
+    case lastblock_at do
+      nil ->
+        false
+
+      %DateTime{} ->
+        age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
+        age > chain.expected_block_intervall() * intervals
+    end
+  end
+
+  @doc """
+  The `lastblock_at` recorded in the WSConn state, or `nil` if the pid
+  is not a live WSConn (dead, handshaking, or another process).
+
+  Used by `NodeProxy` to evaluate eviction without depending on the
+  private `try_get_state/1`.
+  """
+  def lastblock_at(pid) when is_pid(pid) do
+    case try_get_state(pid) do
+      %__MODULE__{lastblock_at: lastblock_at} -> lastblock_at
+      _ -> nil
+    end
+  end
+
+  def lastblock_at(_other), do: nil
 
   @doc """
   Whether the WSConn has stopped receiving block updates even though the
   underlying socket is still alive.
 
-  A connection is stale if its last observed block is older than
-  `chain.expected_block_intervall() * 10` seconds, the same cutoff the
-  `:ping` handler uses to declare a live connection dead. Used by
-  `NodeProxy` to exclude frozen providers from the block-number consensus
-  while keeping the connection in the pool (so it can recover without a
-  restart).
-
   Returns `false` for processes that are not `WSConn` instances or that
   cannot be inspected (dead, handshaking, mid-`sys.get_state` call).
   """
   def stale?(pid, chain) when is_pid(pid) do
-    case try_get_state(pid) do
-      %__MODULE__{lastblock_at: lastblock_at} when not is_nil(lastblock_at) ->
-        age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
-        age > chain.expected_block_intervall() * @stale_threshold_intervals
-
-      _ ->
-        false
-    end
+    stale_at?(lastblock_at(pid), chain)
   end
 
   def stale?(_other, _chain), do: false
@@ -231,15 +255,13 @@ defmodule RemoteChain.WSConn do
   @impl true
   def handle_info(
         :ping,
-        %WSConn{chain: chain, lastblock_at: lastblock_at, ws_url: ws_url} = state
+        %WSConn{chain: chain, ws_url: ws_url} = state
       ) do
     if state.subscription_id == nil do
       raise "No subscription id received, aborting connection with #{ws_url}"
     end
 
-    age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
-
-    if age > chain.expected_block_intervall() * 10 do
+    if stale_at?(state.lastblock_at, chain) do
       {:message_queue_len, len} = Process.info(self(), :message_queue_len)
 
       Logger.warning(

--- a/lib/remote_chain/ws_conn.ex
+++ b/lib/remote_chain/ws_conn.ex
@@ -28,19 +28,29 @@ defmodule RemoteChain.WSConn do
   # A connection is considered stale (and excluded from the block-number
   # consensus) once its last observed block is older than this many expected
   # block intervals. Single source of truth for the staleness threshold used
-  # by `stale?/2`, the `:ping` close handler, and `NodeProxy`'s staleness-
-  # aware consensus.
+  # by `stale?/2`, the `:ping` close handler, `NodeProxy`'s staleness-aware
+  # consensus and eviction, and `ChainList.block_current?/2`.
   @stale_threshold_intervals 10
+
+  @doc """
+  The default staleness threshold expressed as a multiple of
+  `chain.expected_block_intervall()`. Exposed so `ChainList.block_current?/2`
+  can share the same threshold instead of baking the literal `10` into its
+  own predicate.
+  """
+  def stale_threshold_intervals, do: @stale_threshold_intervals
 
   @doc """
   Whether `lastblock_at` is older than the staleness cutoff for `chain`.
 
-  The default cutoff is `chain.expected_block_intervall() * #{@stale_threshold_intervals}`
-  seconds. `intervals` overrides the multiplier — used by `NodeProxy` for
-  its eviction pass (two ping cycles, `@stale_eviction_intervals`).
+  The default cutoff is `chain.expected_block_intervall() *
+  stale_threshold_intervals()` seconds (currently 10 intervals). `intervals`
+  overrides the multiplier — used by `NodeProxy` for its eviction pass (two
+  ping cycles, `@stale_eviction_intervals`).
 
   This is the single threshold shared by `stale?/2` (pid-based), the
-  `:ping` close handler, and `NodeProxy`'s consensus and eviction logic.
+  `:ping` close handler, `NodeProxy`'s consensus and eviction logic, and
+  `ChainList.block_current?/2`.
   """
   def stale_at?(lastblock_at, chain, intervals \\ @stale_threshold_intervals) do
     case lastblock_at do
@@ -72,6 +82,11 @@ defmodule RemoteChain.WSConn do
   @doc """
   Whether the WSConn has stopped receiving block updates even though the
   underlying socket is still alive.
+
+  A stale WSConn is excluded from `NodeProxy`'s block-number consensus and
+  from the `pick_connection/1` rotation (it stays in the pool so it can
+  recover without a restart) and is forcibly evicted after two ping
+  cycles.
 
   Returns `false` for processes that are not `WSConn` instances or that
   cannot be inspected (dead, handshaking, mid-`sys.get_state` call).

--- a/test/remote_chain/chain_list_test.exs
+++ b/test/remote_chain/chain_list_test.exs
@@ -257,6 +257,30 @@ defmodule RemoteChain.ChainListTest do
     end
   end
 
+  describe "live_ws_endpoints/2" do
+    test "includes additional endpoints (fallback URLs) that pass test?/2" do
+      with_ws_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
+        assert RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url]) == [url]
+      end)
+    end
+
+    test "drops an additional endpoint that fails the staleness probe" do
+      # Regression for us1: a fallback URL like the simplystaking.xyz
+      # endpoint returns 403 on the HTTP probe and must be excluded from
+      # the live list so NodeProxy does not re-attach it.
+      url = "https://unreachable.invalid/rpc"
+      assert RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url]) == []
+    end
+
+    test "deduplicates the union of chainlist and additional URLs" do
+      with_ws_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
+        # The same URL appears in both lists; the result must be unique.
+        result = RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url, url])
+        assert result == [url]
+      end)
+    end
+  end
+
   defp mock_ref(), do: {__MODULE__, :current_mock}
 
   defp hex_timestamp(seconds), do: "0x" <> Integer.to_string(seconds, 16)

--- a/test/remote_chain/node_proxy_test.exs
+++ b/test/remote_chain/node_proxy_test.exs
@@ -16,11 +16,21 @@ defmodule RemoteChain.NodeProxyTest do
     use GenServer
 
     def start(started_at) do
-      GenServer.start(__MODULE__, started_at)
+      GenServer.start(__MODULE__, %WSConn{started_at: started_at})
+    end
+
+    def start_state(%WSConn{} = state), do: GenServer.start(__MODULE__, state)
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_info({:"$websockex_cast", :close}, state) do
+      {:stop, :normal, state}
     end
 
     @impl true
-    def init(started_at), do: {:ok, %WSConn{started_at: started_at}}
+    def handle_info(_msg, state), do: {:noreply, state}
   end
 
   defp stale_started_at do
@@ -387,6 +397,198 @@ defmodule RemoteChain.NodeProxyTest do
 
       refute NodeProxy.rate_limited_disconnect?(:normal)
       refute NodeProxy.rate_limited_disconnect?({:error, :closed})
+    end
+  end
+
+  describe "handle_info({:new_block, ...}) consensus" do
+    # Regression for the us1/Oasis incident: a fallback WSConn silently
+    # stopped pushing newHeads frames while staying connected. The primary
+    # provider kept advancing, but `NodeProxy` published the stale fallback
+    # block forever because the consensus required 2/2 votes.
+    @primary_url "wss://primary.example/ws"
+    @fallback_url "wss://fallback.example/oasis/mainnet/"
+
+    defp fresh_date, do: DateTime.utc_now()
+
+    defp alive_noop_pid do
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+    end
+
+    defp build_state(primary_lastblocks, fallback) do
+      %NodeProxy{
+        chain: Chains.OasisSapphire,
+        connections: %{@primary_url => alive_noop_pid()},
+        fallback: fallback,
+        fallback_url: if(fallback, do: @fallback_url, else: nil),
+        lastblocks: primary_lastblocks,
+        lastblock: 0
+      }
+    end
+
+    defp stub_fallback(lastblock_at) do
+      {:ok, pid} =
+        WSConnStateStub.start_state(%WSConn{started_at: lastblock_at, lastblock_at: lastblock_at})
+
+      pid
+    end
+
+    defp apply_new_block(state, url, block) do
+      {:noreply, new_state} = NodeProxy.handle_info({:new_block, url, block}, state)
+      new_state
+    end
+
+    test "ignores a frozen fallback when the primary advances (the us1/Oasis bug)" do
+      fallback = stub_fallback(DateTime.add(fresh_date(), -30 * 60, :second))
+      state = build_state(%{}, fallback)
+
+      state = apply_new_block(state, @primary_url, 20)
+
+      # Without the fix, published block stays at 0 because the frozen
+      # fallback only has block 10 and security_level is 2. With the fix,
+      # the frozen fallback is excluded from the quorum and the primary
+      # alone advances the published block.
+      assert state.lastblock == 20
+    end
+
+    test "advances when both providers are live and reporting recent blocks" do
+      fallback = stub_fallback(fresh_date())
+      state = build_state(%{}, fallback)
+
+      state = apply_new_block(state, @primary_url, 10)
+      # Only the primary has reached 10. With security_level = 2 (fallback
+      # configured), the published block stays at 0.
+      assert state.lastblock == 0
+
+      state = apply_new_block(state, @fallback_url, 10)
+      # Both providers agree at 10; the published block advances.
+      assert state.lastblock == 10
+    end
+
+    test "re-admits a previously-frozen fallback once it posts a fresh block" do
+      stale_ts = DateTime.add(fresh_date(), -30 * 60, :second)
+
+      # Both the WSConn's `lastblock_at` and the cached `lastblocks` entry
+      # are stale. The fallback is treated as not present for the consensus.
+      fallback = stub_fallback(stale_ts)
+
+      state =
+        build_state(
+          %{@fallback_url => {10, stale_ts}},
+          fallback
+        )
+
+      # Primary alone advances to 22 (fallback is stale, security_level = 1).
+      state = apply_new_block(state, @primary_url, 22)
+      assert state.lastblock == 22
+
+      # Fallback recovers with a fresh block at 22. With security_level = 2
+      # the consensus now needs two providers at 22, so the published block
+      # advances to 22.
+      state = apply_new_block(state, @fallback_url, 22)
+      assert state.lastblock == 22
+    end
+
+    test "degrades to security_level=1 when no fallback is configured" do
+      state = build_state(%{}, nil)
+
+      state = apply_new_block(state, @primary_url, 5)
+      assert state.lastblock == 5
+    end
+
+    test "degrades to security_level=1 when the configured fallback is stale" do
+      fallback = stub_fallback(DateTime.add(fresh_date(), -30 * 60, :second))
+      state = build_state(%{}, fallback)
+
+      # Even though `fallback != nil`, the staleness check should drop
+      # security_level back to 1 so the primary advances.
+      state = apply_new_block(state, @primary_url, 5)
+      assert state.lastblock == 5
+    end
+
+    test "ignores newHeads from a stale provider when computing the quorum" do
+      # Both providers have stale entries in lastblocks (the test simulates
+      # a scenario where a provider was previously healthy but now silent).
+      stale_ts = DateTime.add(fresh_date(), -30 * 60, :second)
+      fallback = stub_fallback(stale_ts)
+
+      state =
+        build_state(
+          %{
+            @primary_url => {5, stale_ts},
+            @fallback_url => {5, stale_ts}
+          },
+          fallback
+        )
+
+      state = apply_new_block(state, @primary_url, 6)
+
+      # The primary's new block has a fresh `lastblock_at`, but the
+      # fallback's entry is stale. Stale entries contribute zero votes, so
+      # the primary's single live vote satisfies the (now-degraded)
+      # security_level = 1.
+      assert state.lastblock == 6
+    end
+  end
+
+  describe "prune_stale_connections/1 eviction" do
+    @fallback_url "wss://fallback.example/oasis/mainnet/"
+
+    defp with_fallback(state, lastblock_at) do
+      # Mark the stub as ready (so the handshake-stale check is not the
+      # one evicting) and use a started_at that is within the handshake
+      # timeout. Only the data-staleness check should apply.
+      started_at = DateTime.utc_now()
+      {:ok, fallback} = WSConnStateStub.start_state(%WSConn{started_at: started_at})
+      Globals.put({WSConn, fallback}, :fake_conn)
+      # Stash the desired lastblock_at into the stub via :sys.replace_state.
+      :sys.replace_state(fallback, fn %WSConn{} = wsconn ->
+        %{wsconn | lastblock_at: lastblock_at}
+      end)
+
+      %{state | fallback: fallback, fallback_url: @fallback_url}
+    end
+
+    defp build_min_state do
+      %NodeProxy{
+        chain: Chains.OasisSapphire,
+        connections: %{},
+        fallback: nil,
+        fallback_url: nil,
+        lastblocks: %{}
+      }
+    end
+
+    test "evicts a fallback that has not produced a block for >20 block intervals" do
+      # 30 minutes = 1800s on a 6s cadence = 300 intervals, well past the
+      # 20-interval (120s) eviction cutoff for Oasis.
+      very_stale = DateTime.add(DateTime.utc_now(), -1800, :second)
+
+      state =
+        build_min_state()
+        |> with_fallback(very_stale)
+        |> Map.put(:lastblocks, %{@fallback_url => {10, very_stale}})
+
+      new_state = NodeProxy.prune_stale_connections(state)
+
+      assert new_state.fallback == nil
+      assert new_state.fallback_url == nil
+    end
+
+    test "keeps a fallback that has produced a block within the last 20 intervals" do
+      # 30s on Oasis (6s cadence) = 5 intervals, well below the 20-interval
+      # eviction cutoff.
+      fresh = DateTime.add(DateTime.utc_now(), -30, :second)
+      state = with_fallback(build_min_state(), fresh)
+      state = %{state | lastblocks: %{@fallback_url => {10, fresh}}}
+
+      new_state = NodeProxy.prune_stale_connections(state)
+
+      assert new_state.fallback == state.fallback
+      assert new_state.fallback_url == @fallback_url
     end
   end
 end

--- a/test/remote_chain/node_proxy_test.exs
+++ b/test/remote_chain/node_proxy_test.exs
@@ -537,31 +537,6 @@ defmodule RemoteChain.NodeProxyTest do
   describe "prune_stale_connections/1 eviction" do
     @fallback_url "wss://fallback.example/oasis/mainnet/"
 
-    defp with_fallback(state, lastblock_at) do
-      # Mark the stub as ready (so the handshake-stale check is not the
-      # one evicting) and use a started_at that is within the handshake
-      # timeout. Only the data-staleness check should apply.
-      started_at = DateTime.utc_now()
-      {:ok, fallback} = WSConnStateStub.start_state(%WSConn{started_at: started_at})
-      Globals.put({WSConn, fallback}, :fake_conn)
-      # Stash the desired lastblock_at into the stub via :sys.replace_state.
-      :sys.replace_state(fallback, fn %WSConn{} = wsconn ->
-        %{wsconn | lastblock_at: lastblock_at}
-      end)
-
-      %{state | fallback: fallback, fallback_url: @fallback_url}
-    end
-
-    defp build_min_state do
-      %NodeProxy{
-        chain: Chains.OasisSapphire,
-        connections: %{},
-        fallback: nil,
-        fallback_url: nil,
-        lastblocks: %{}
-      }
-    end
-
     test "evicts a fallback that has not produced a block for >20 block intervals" do
       # 30 minutes = 1800s on a 6s cadence = 300 intervals, well past the
       # 20-interval (120s) eviction cutoff for Oasis.
@@ -597,27 +572,38 @@ defmodule RemoteChain.NodeProxyTest do
       # eviction contract entirely. The fix uses the WSConn's own
       # `lastblock_at` (initialised at start) as a fallback.
       very_stale = DateTime.add(DateTime.utc_now(), -1800, :second)
-      started_at = DateTime.utc_now()
-
-      {:ok, fallback} = WSConnStateStub.start_state(%WSConn{started_at: started_at})
-      Globals.put({WSConn, fallback}, :fake_conn)
-
-      :sys.replace_state(fallback, fn %WSConn{} = wsconn ->
-        %{wsconn | lastblock_at: very_stale}
-      end)
-
-      state = %NodeProxy{
-        chain: Chains.OasisSapphire,
-        connections: %{},
-        fallback: fallback,
-        fallback_url: @fallback_url,
-        lastblocks: %{}
-      }
+      state = with_fallback(build_min_state(), very_stale)
 
       new_state = NodeProxy.prune_stale_connections(state)
 
       assert new_state.fallback == nil
       assert new_state.fallback_url == nil
     end
+  end
+
+  # Shared helpers for the `prune_stale_connections/1` eviction tests.
+  # Mark the stub as ready (so the handshake-stale check is not the one
+  # evicting) and use a started_at that is within the handshake timeout.
+  # Only the data-staleness check should apply.
+  defp with_fallback(state, lastblock_at) do
+    started_at = DateTime.utc_now()
+    {:ok, fallback} = WSConnStateStub.start_state(%WSConn{started_at: started_at})
+    Globals.put({WSConn, fallback}, :fake_conn)
+
+    :sys.replace_state(fallback, fn %WSConn{} = wsconn ->
+      %{wsconn | lastblock_at: lastblock_at}
+    end)
+
+    %{state | fallback: fallback, fallback_url: "wss://fallback.example/oasis/mainnet/"}
+  end
+
+  defp build_min_state do
+    %NodeProxy{
+      chain: Chains.OasisSapphire,
+      connections: %{},
+      fallback: nil,
+      fallback_url: nil,
+      lastblocks: %{}
+    }
   end
 end

--- a/test/remote_chain/node_proxy_test.exs
+++ b/test/remote_chain/node_proxy_test.exs
@@ -590,5 +590,34 @@ defmodule RemoteChain.NodeProxyTest do
       assert new_state.fallback == state.fallback
       assert new_state.fallback_url == @fallback_url
     end
+
+    test "evicts a never-blocked connection whose WSConn has gone stale" do
+      # Regression: a WSConn that finished its handshake but never received
+      # a newHeads frame (no entry in `lastblocks`) used to skip the
+      # eviction contract entirely. The fix uses the WSConn's own
+      # `lastblock_at` (initialised at start) as a fallback.
+      very_stale = DateTime.add(DateTime.utc_now(), -1800, :second)
+      started_at = DateTime.utc_now()
+
+      {:ok, fallback} = WSConnStateStub.start_state(%WSConn{started_at: started_at})
+      Globals.put({WSConn, fallback}, :fake_conn)
+
+      :sys.replace_state(fallback, fn %WSConn{} = wsconn ->
+        %{wsconn | lastblock_at: very_stale}
+      end)
+
+      state = %NodeProxy{
+        chain: Chains.OasisSapphire,
+        connections: %{},
+        fallback: fallback,
+        fallback_url: @fallback_url,
+        lastblocks: %{}
+      }
+
+      new_state = NodeProxy.prune_stale_connections(state)
+
+      assert new_state.fallback == nil
+      assert new_state.fallback_url == nil
+    end
   end
 end

--- a/test/remote_chain/ws_conn_test.exs
+++ b/test/remote_chain/ws_conn_test.exs
@@ -1,0 +1,76 @@
+defmodule RemoteChain.WSConnTest do
+  use ExUnit.Case, async: true
+
+  alias RemoteChain.WSConn
+
+  defmodule WSConnStateStub do
+    @moduledoc """
+    In-process stand-in for a WSConn so the staleness predicate can be
+    tested without opening a real socket. `:sys.get_state/2` returns the
+    `WSConn` struct we configure here.
+    """
+    use GenServer
+
+    def start(state) do
+      GenServer.start(__MODULE__, state)
+    end
+
+    @impl true
+    def init(state), do: {:ok, state}
+  end
+
+  describe "stale?/2" do
+    test "is false for a connection whose last block is fresh" do
+      {:ok, pid} = WSConnStateStub.start(%WSConn{lastblock_at: DateTime.utc_now()})
+      refute WSConn.stale?(pid, Chains.Anvil)
+    end
+
+    test "is true once the last block is older than expected_block_intervall * 10" do
+      # Anvil uses 15s intervals; 11 intervals = 165s puts us clearly past the
+      # 10-interval cutoff of 150s.
+      stale_at = DateTime.utc_now() |> DateTime.add(-11 * 15, :second)
+
+      {:ok, pid} = WSConnStateStub.start(%WSConn{lastblock_at: stale_at})
+      assert WSConn.stale?(pid, Chains.Anvil)
+    end
+
+    test "uses the chain's expected_block_intervall, not a fixed threshold" do
+      # Oasis uses 6s intervals; 11 intervals = 66s is past the 60s cutoff,
+      # but only 11s on Anvil where the cutoff is 150s.
+      oasis_stale_at = DateTime.utc_now() |> DateTime.add(-11 * 6, :second)
+
+      {:ok, oasis_pid} = WSConnStateStub.start(%WSConn{lastblock_at: oasis_stale_at})
+      assert WSConn.stale?(oasis_pid, Chains.OasisSapphire)
+
+      # Anvil cutoff is 150s; 11s is fresh on Anvil.
+      fresh_at = DateTime.utc_now() |> DateTime.add(-11, :second)
+
+      {:ok, anvil_pid} = WSConnStateStub.start(%WSConn{lastblock_at: fresh_at})
+      refute WSConn.stale?(anvil_pid, Chains.Anvil)
+    end
+
+    test "is false for a process that is not a WSConn" do
+      pid = spawn(fn -> receive do: (:stop -> :ok) end)
+
+      try do
+        refute WSConn.stale?(pid, Chains.Anvil)
+      after
+        send(pid, :stop)
+      end
+    end
+
+    test "is false for a WSConn that has never observed a block" do
+      # `lastblock_at` is nil until the first newHeads frame arrives. A
+      # handshake-only connection must not be classified as stale.
+      {:ok, pid} = WSConnStateStub.start(%WSConn{lastblock_at: nil})
+      refute WSConn.stale?(pid, Chains.Anvil)
+    end
+
+    test "is false for a dead pid" do
+      pid = spawn(fn -> :ok end)
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+      refute WSConn.stale?(pid, Chains.Anvil)
+    end
+  end
+end

--- a/test/remote_chain/ws_conn_test.exs
+++ b/test/remote_chain/ws_conn_test.exs
@@ -1,22 +1,23 @@
 defmodule RemoteChain.WSConnTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias RemoteChain.WSConn
 
+  # In-process stand-in for a WSConn so the staleness predicate can be
+  # tested without opening a real socket. Mirrors the more capable
+  # `WSConnStateStub` in `NodeProxyTest`; intentionally small here
+  # because these tests only need `:sys.get_state/2` to return a
+  # `%WSConn{}` struct.
   defmodule WSConnStateStub do
-    @moduledoc """
-    In-process stand-in for a WSConn so the staleness predicate can be
-    tested without opening a real socket. `:sys.get_state/2` returns the
-    `WSConn` struct we configure here.
-    """
     use GenServer
 
-    def start(state) do
-      GenServer.start(__MODULE__, state)
-    end
+    def start(state), do: GenServer.start(__MODULE__, state)
 
     @impl true
     def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_info(_msg, state), do: {:noreply, state}
   end
 
   describe "stale?/2" do

--- a/test/remote_chain/ws_conn_test.exs
+++ b/test/remote_chain/ws_conn_test.exs
@@ -1,5 +1,5 @@
 defmodule RemoteChain.WSConnTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias RemoteChain.WSConn
 
@@ -72,6 +72,21 @@ defmodule RemoteChain.WSConnTest do
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
       refute WSConn.stale?(pid, Chains.Anvil)
+    end
+  end
+
+  describe "stale_at?/3" do
+    test "honours the intervals override, not just the default 10" do
+      # 16s old on Anvil (15s cadence) is fresh under the default 10-interval
+      # (150s) cutoff but stale under a 1-interval (15s) cutoff.
+      sixteen_seconds_ago = DateTime.utc_now() |> DateTime.add(-16, :second)
+
+      refute WSConn.stale_at?(sixteen_seconds_ago, Chains.Anvil)
+      assert WSConn.stale_at?(sixteen_seconds_ago, Chains.Anvil, 1)
+    end
+
+    test "stale_threshold_intervals/0 exposes the default as the same constant" do
+      assert WSConn.stale_threshold_intervals() == 10
     end
   end
 end


### PR DESCRIPTION
## Summary

NodeProxy's block-number consensus required 2/2 votes whenever a fallback was configured. A fallback WSConn that silently stopped pushing `newHeads` frames while staying connected (the `spectrum-02.simplystaking.xyz` endpoint on us1) therefore froze the published Oasis block at its last value forever. PR #24 added a startup-time staleness probe in `ChainList` but had no effect on a provider that became stale after acceptance, and it did not run against fallback URLs at all (fallback URLs come from the `OASIS_SAPPHIRE_WS_FALLBACK` env var, never touched `ChainList.test?/2`).

This change:

- Adds `RemoteChain.WSConn.stale?/2`, a public predicate using the same `expected_block_intervall() * 10` cutoff the existing `:ping` close uses.
- Tracks `lastblock_at` alongside each provider's last block in `NodeProxy.lastblocks`, and excludes stale voters from the consensus. `security_level` is computed dynamically so a stale or dead fallback drops back to 1-vote consensus (matches the Q1 "hold until recover" intent, with a degraded fallback that still tolerates a primary outage).
- Evicts a fallback that has been silent for two ping cycles (`@stale_eviction_intervals = 20`), then refills via `ChainList.live_ws_endpoints/2` so a permanently stale URL is not re-attached.
- Adds `RemoteChain.ChainList.live_ws_endpoints/2` that filters both chainlist URLs and supplied fallback URLs through `test?/2`.

## us1 verification

After deploy, expect:

```bash
ssh us1 '/opt/diode_node/bin/diode_node rpc "IO.inspect(RemoteChain.RPCCache.block_number(Chains.OasisSapphire))"'
```

Block number advances past `15164397` within ~30 s (staleness exclusion kicks in immediately) and within ~2 min the frozen simplystaking fallback is evicted and no longer voted on.

## Tests

- `test/remote_chain/ws_conn_test.exs` (new): 6 tests for `stale?/2` (fresh, stale, per-chain intervals, dead pid, non-WSConn, uninitialized).
- `test/remote_chain/node_proxy_test.exs` (extended): 6 consensus regression tests, including the exact us1/Oasis scenario, plus 2 eviction tests. This is the test coverage that PR #24 was missing.
- `test/remote_chain/chain_list_test.exs` (extended): 3 tests for `live_ws_endpoints/2`.

`mix format --check-formatted`, `mix lint` (Credo 0 issues, Dialyzer 0 errors), and `DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/ test/diode/` (82 tests pass).

## Behavior summary

| Scenario | Before | After |
| --- | --- | --- |
| Primary live, fallback frozen | Block frozen at fallback's last value | Block advances with primary alone |
| Both live, agree on N | Block advances to N (unchanged) | Block advances to N (unchanged) |
| Fallback recovers and reports N | Already working | Re-admitted to quorum immediately |
| Fallback never recovers | Block frozen forever | Evicted within 2 ping cycles, then refilled only if `ChainList.live_ws_endpoints/2` returns another live URL |
| No fallback configured | Single-vote consensus | Single-vote consensus (unchanged) |
| Fallback URL fails `eth_chainId` probe | Re-attached every restart, dead silent | Dropped by `live_ws_endpoints/2` on next refill |
