### PR TITLE
Restore canonical endpoint resolution path

### DIFF
--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -18,36 +18,16 @@ defmodule RemoteChain.ChainList do
 
   @doc """
   WebSocket endpoints for `chain`, optionally extended with caller-supplied
-  URLs. Returns only endpoints that pass the staleness probe.
+  URLs.
 
-  Callers that supply their own fallback URLs (e.g. `NodeProxy`) should
-  prefer `live_ws_endpoints/2` instead — `ws_endpoints/2` does not re-test
-  the additional URLs on every call, so a permanently stale fallback would
-  be re-attached after every eviction. See `live_ws_endpoints/2`.
+  Only URLs from the community chainlist pass the staleness probe. Caller
+  `additional_endpoints` (e.g. ChainImpl extras) are appended without
+  filtering so env/ChainImpl overrides remain available via the canonical
+  path RemoteChain -> ChainImpl -> ChainList.
   """
   def ws_endpoints(chain, additional_endpoints \\ []) do
     endpoints(chain, additional_endpoints)[:ws]
     |> check_endpoints(chain)
-  end
-
-  @doc """
-  WebSocket endpoints that are currently considered live for `chain`,
-  including the supplied `additional_endpoints` (typically the configured
-  fallback URLs).
-
-  `ws_endpoints/2` already runs every chainlist URL through `test?/2`, so
-  the chain URLs need no further filtering; this function re-tests only the
-  `additional_endpoints`. A `ws_endpoints/2` that returns `nil` (chain id
-  not in the chainlist) is treated as "no chain URLs, only additional" so
-  this function still has well-defined behaviour for unknown chains.
-
-  Used by `NodeProxy.ensure_connections/1` to keep permanently stale
-  fallback URLs (e.g. simplystaking.xyz on us1) from being re-attached.
-  """
-  def live_ws_endpoints(chain, additional_endpoints \\ []) do
-    chain_urls = ws_endpoints(chain) || []
-    extra_live = Enum.filter(additional_endpoints, fn url -> test?(url, chain) end)
-    Enum.uniq(chain_urls ++ extra_live)
   end
 
   defp check_endpoints(endpoints, chain) do
@@ -62,9 +42,11 @@ defmodule RemoteChain.ChainList do
     chain_id = RemoteChain.chainimpl(chain).chain_id()
     rpc = get(chain_id)["rpc"] || []
 
-    Enum.map(rpc, fn rpc -> rpc["url"] end)
-    |> Enum.concat(additional_endpoints)
-    |> filter_endpoints(chain)
+    chainlist_urls = Enum.map(rpc, fn entry -> entry["url"] end)
+    filtered = filter_endpoints(chainlist_urls, chain)
+
+    (filtered ++ additional_endpoints)
+    |> Enum.uniq()
     |> Enum.group_by(fn endpoint ->
       cond do
         String.ends_with?(endpoint, "/http") -> :rpc

--- a/lib/remote_chain/edge.ex
+++ b/lib/remote_chain/edge.ex
@@ -380,7 +380,7 @@ defmodule RemoteChain.Edge do
     # In order to ensure delivery we're broadcasting to all known endpoints of this chain
     RemoteChain.RPC.send_raw_transaction(chain, payload)
 
-    for endpoint <- Enum.shuffle(chain.rpc_endpoints()) do
+    for endpoint <- Enum.shuffle(RemoteChain.rpc_endpoints(chain)) do
       RemoteChain.HTTP.send_raw_transaction(endpoint, payload)
     end
   end

--- a/lib/remote_chain/node_proxy.ex
+++ b/lib/remote_chain/node_proxy.ex
@@ -563,15 +563,12 @@ defmodule RemoteChain.NodeProxy do
     state = prune_stale_connections(state)
     %NodeProxy{connections: connections, fallback: fallback} = state
 
-    # Apply `live_ws_endpoints/1` to BOTH the primary list and the configured
-    # fallback URLs. Without filtering fallback URLs, a permanently stale
-    # WS-only fallback (e.g. the simplystaking.xyz endpoint on us1) would be
-    # re-attached after every eviction and silently freeze the published
-    # block number forever.
-    fallback_candidates = RemoteChain.ws_fallback_endpoints(chain)
-    urls = MapSet.new(RemoteChain.ChainList.live_ws_endpoints(chain, fallback_candidates))
+    # Canonical path: RemoteChain (env) -> ChainImpl -> ChainList.
+    # Do not call ChainList directly here; that skips CHAINS_*_WS overrides.
+    urls = MapSet.new(RemoteChain.ws_endpoints(chain))
     existing = MapSet.new(Map.keys(connections))
     new_urls = MapSet.difference(urls, existing) |> Enum.to_list() |> Enum.shuffle()
+    fallback_candidates = RemoteChain.ws_fallback_endpoints(chain)
     fallback_url = List.first(Enum.shuffle(fallback_candidates) ++ new_urls)
 
     cond do

--- a/test/remote_chain/chain_list_test.exs
+++ b/test/remote_chain/chain_list_test.exs
@@ -257,26 +257,64 @@ defmodule RemoteChain.ChainListTest do
     end
   end
 
-  describe "live_ws_endpoints/2" do
-    test "includes additional endpoints (fallback URLs) that pass test?/2" do
-      with_ws_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
-        assert RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url]) == [url]
+  describe "endpoints/2 filtering scope" do
+    test "appends additional endpoints without a health probe" do
+      # Additional URLs (ChainImpl extras / overrides) must remain available even
+      # when they would fail test?/2. Only chainlist entries are filtered.
+      dead = "wss://unreachable.invalid/ws-additional"
+      assert RemoteChain.ChainList.ws_endpoints(Chains.Anvil, [dead]) == [dead]
+      # Ensure we never ran a probe that would hang on DNS.
+      assert Globals.get({RemoteChain.ChainList, :test, dead}) == nil
+    end
+
+    test "drops chainlist URLs that fail the health probe" do
+      chain_id = Chains.Anvil.chain_id()
+      dead_ws = "wss://unreachable-chainlist.invalid/ws"
+      dead_rpc = "https://unreachable-chainlist.invalid/rpc"
+      extra_ws = "ws://override.example/ws"
+
+      Globals.put(@loaded_key, true)
+
+      Globals.put(cache_key(chain_id), %{
+        "chainId" => chain_id,
+        "name" => "anvil-filter-scope",
+        "rpc" => [%{"url" => dead_rpc}, %{"url" => dead_ws}]
+      })
+
+      # Pre-seed failed verdicts so filter_endpoints does not open the network.
+      now = System.monotonic_time(:millisecond)
+      Globals.put({RemoteChain.ChainList, :test, dead_ws}, {false, now})
+      Globals.put({RemoteChain.ChainList, :test, dead_rpc}, {false, now})
+
+      on_exit(fn ->
+        Globals.pop(cache_key(chain_id))
+        Globals.pop({RemoteChain.ChainList, :test, dead_ws})
+        Globals.pop({RemoteChain.ChainList, :test, dead_rpc})
+        clear_chain_cache()
       end)
+
+      ws = RemoteChain.ChainList.ws_endpoints(Chains.Anvil, [extra_ws])
+      rpc = RemoteChain.ChainList.rpc_endpoints(Chains.Anvil, [extra_ws])
+
+      assert ws == [extra_ws]
+      refute dead_ws in (ws || [])
+      # WS-looking additional must land in :ws, not poison the rpc list when grouped.
+      assert rpc == nil or dead_rpc not in rpc
     end
 
-    test "drops an additional endpoint that fails the staleness probe" do
-      # Regression for us1: a fallback URL like the simplystaking.xyz
-      # endpoint returns 403 on the HTTP probe and must be excluded from
-      # the live list so NodeProxy does not re-attach it.
-      url = "https://unreachable.invalid/rpc"
-      assert RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url]) == []
-    end
-
-    test "deduplicates the union of chainlist and additional URLs" do
+    test "deduplicates filtered chainlist and additional URLs" do
       with_ws_mock([timestamp: hex_timestamp(System.os_time(:second))], fn url ->
-        # The same URL appears in both lists; the result must be unique.
-        result = RemoteChain.ChainList.live_ws_endpoints(Chains.Anvil, [url, url])
-        assert result == [url]
+        Globals.put(@loaded_key, true)
+
+        Globals.put(cache_key(Chains.Anvil.chain_id()), %{
+          "chainId" => Chains.Anvil.chain_id(),
+          "name" => "anvil-dedupe",
+          "rpc" => [%{"url" => url}]
+        })
+
+        on_exit(&clear_chain_cache/0)
+
+        assert RemoteChain.ChainList.ws_endpoints(Chains.Anvil, [url, url]) == [url]
       end)
     end
   end

--- a/test/remote_chain/remote_chain_test.exs
+++ b/test/remote_chain/remote_chain_test.exs
@@ -3,7 +3,7 @@
 # Licensed under the Diode License, Version 1.1
 
 defmodule RemoteChainTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   describe "accepts_transactions?/1" do
     test "returns false for Moonbeam (module, chain id, and prefix)" do
@@ -16,6 +16,61 @@ defmodule RemoteChainTest do
       assert RemoteChain.accepts_transactions?(Chains.Diode)
       assert RemoteChain.accepts_transactions?(Chains.OasisSapphire)
       assert RemoteChain.accepts_transactions?(Chains.Base)
+    end
+  end
+
+  describe "ws_endpoints/1 env override" do
+    @env_key "CHAINS_DIODE_WS"
+
+    setup do
+      prev = System.get_env(@env_key)
+
+      on_exit(fn ->
+        if prev, do: System.put_env(@env_key, prev), else: System.delete_env(@env_key)
+      end)
+
+      :ok
+    end
+
+    test "bang prefix replaces ChainImpl defaults" do
+      System.put_env(@env_key, "!ws://local-override.example/ws")
+      assert RemoteChain.ws_endpoints(Chains.Diode) == ["ws://local-override.example/ws"]
+    end
+
+    test "bare value replaces ChainImpl defaults" do
+      System.put_env(@env_key, "ws://bare-override.example/ws")
+      assert RemoteChain.ws_endpoints(Chains.Diode) == ["ws://bare-override.example/ws"]
+    end
+
+    test "plus prefix prepends to ChainImpl defaults" do
+      System.put_env(@env_key, "+ws://extra.example/ws")
+      result = RemoteChain.ws_endpoints(Chains.Diode)
+      assert hd(result) == "ws://extra.example/ws"
+      assert Chains.Diode.ws_endpoints() -- result == []
+    end
+
+    test "unset env uses ChainImpl list" do
+      System.delete_env(@env_key)
+      assert RemoteChain.ws_endpoints(Chains.Diode) == Chains.Diode.ws_endpoints()
+    end
+  end
+
+  describe "rpc_endpoints/1 env override" do
+    @env_key "CHAINS_DIODE_RPC"
+
+    setup do
+      prev = System.get_env(@env_key)
+
+      on_exit(fn ->
+        if prev, do: System.put_env(@env_key, prev), else: System.delete_env(@env_key)
+      end)
+
+      :ok
+    end
+
+    test "bang prefix replaces ChainImpl rpc defaults" do
+      System.put_env(@env_key, "!http://local-override.example:3834")
+      assert RemoteChain.rpc_endpoints(Chains.Diode) == ["http://local-override.example:3834"]
     end
   end
 end


### PR DESCRIPTION
## Summary
- Restore `NodeProxy.ensure_connections/1` so primary WS URLs come from `RemoteChain.ws_endpoints/1` (env → ChainImpl → ChainList) instead of a direct `ChainList.live_ws_endpoints/2` call that ignored `CHAINS_*_WS` overrides.
- Health-filter only community chainlist URLs in `ChainList.endpoints/2`; append ChainImpl `additional_endpoints` unfiltered. Remove `live_ws_endpoints/2`.
- Route Edge raw-tx broadcast through `RemoteChain.rpc_endpoints/1` so RPC env overrides apply.
- Keep PR #25 runtime staleness (data-stale eviction, stale-voter consensus).

## Context
On as1, Diode NodeProxy had zero connections because live list resolution used only chainlist URLs (all stale) and never consulted `CHAINS_DIODE_WS` / `Chains.Diode.ws_endpoints/0`. That caused mass `getblockquick2` hangs and Edge ticket timeouts.

## Test plan
- [x] `DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/`
- [x] `mix lint`
- [ ] Confirm with env `CHAINS_DIODE_WS=!ws://…` that `RemoteChain.ws_endpoints(Chains.Diode)` matches the override after deploy
- [ ] On a stuck node: NodeProxy connections refill from the configured WS list without needing a chainlist entry


Made with [Cursor](https://cursor.com)