### PR TITLE
Disable staleness watchdog for frozen Moonbeam chain

### DIFF
--- a/lib/chains/chains.ex
+++ b/lib/chains/chains.ex
@@ -132,6 +132,14 @@ end
 defmodule Chains.Moonbeam do
   alias DiodeClient.{Base16, Hash}
 
+  @doc """
+  Last block Moonbeam produced before the chain halted. Treated as the
+  permanent head by `RemoteChain` so the staleness watchdog does not keep
+  evicting healthy connections to a chain that will never produce another
+  block. Update this if/when the chain resumes or hard-forks.
+  """
+  @final_block_number 16_796_699
+
   def chain_id(), do: 1284
   def expected_block_intervall(), do: 6
   def epoch(n), do: Chains.epoch(__MODULE__, n)
@@ -141,6 +149,17 @@ defmodule Chains.Moonbeam do
 
   def epoch_duration(), do: 2_592_000
   def chain_prefix(), do: "glmr"
+
+  @doc """
+  Whether this chain has stopped producing blocks permanently. When true,
+  the WSConn staleness watchdog is disabled (the chain will never satisfy
+  it) and the provider's `latest` block must match `final_block_number/0`
+  for endpoint health checks.
+  """
+  def frozen?, do: true
+
+  @doc "The final block number of this chain. Only meaningful when `frozen?/0` is true."
+  def final_block_number, do: @final_block_number
 
   def additional_endpoints() do
     ~w(

--- a/lib/remote_chain/chain_list.ex
+++ b/lib/remote_chain/chain_list.ex
@@ -213,8 +213,30 @@ defmodule RemoteChain.ChainList do
   skew is bounded separately by `@max_future_skew_seconds` because the
   staleness predicate only checks how stale a `lastblock_at` is — never how
   far in the future it sits.
+
+  Frozen chains (see `RemoteChain.frozen?/1`) have a fixed head; any
+  provider that returns a block matching `RemoteChain.final_block_number/1`
+  is considered current regardless of timestamp age, because age and
+  staleness are not meaningful when the chain will never produce a newer
+  block.
   """
-  def block_current?(chain, %{"timestamp" => timestamp}) when is_binary(timestamp) do
+  def block_current?(chain, block) when is_map(block) do
+    cond do
+      RemoteChain.frozen?(chain) ->
+        final = RemoteChain.final_block_number(chain)
+        is_integer(final) and current_by_block_number?(block, final)
+
+      is_binary(block["timestamp"]) ->
+        block_current_by_timestamp(chain, block["timestamp"])
+
+      true ->
+        false
+    end
+  end
+
+  def block_current?(_chain, _block), do: false
+
+  defp block_current_by_timestamp(chain, timestamp) do
     block_ts = Base16.decode_int(timestamp)
     now = System.os_time(:second)
     age = now - block_ts
@@ -223,7 +245,11 @@ defmodule RemoteChain.ChainList do
       not RemoteChain.WSConn.stale_at?(block_age_to_lastblock_at(now, age), chain)
   end
 
-  def block_current?(_chain, _block), do: false
+  defp current_by_block_number?(%{"number" => number}, final) when is_binary(number) do
+    Base16.decode_int(number) == final
+  end
+
+  defp current_by_block_number?(_block, _final), do: false
 
   @doc false
   def timestamp_current?(max_age_seconds, block_timestamp)

--- a/lib/remote_chain/remote_chain.ex
+++ b/lib/remote_chain/remote_chain.ex
@@ -96,6 +96,33 @@ defmodule RemoteChain do
     chainimpl(chain) != Chains.Moonbeam
   end
 
+  @doc """
+  Whether the chain has stopped producing blocks permanently.
+
+  Opt-in per chain via `Chain.frozen?/0`; defaults to `false` for chains
+  that do not declare the function. Used to disable the WSConn staleness
+  watchdog and the endpoint freshness check, both of which would otherwise
+  reject healthy connections to a chain whose head is fixed.
+  """
+  def frozen?(chain) do
+    impl = chainimpl(chain)
+    Code.ensure_loaded?(impl) and function_exported?(impl, :frozen?, 0) and impl.frozen?()
+  end
+
+  @doc """
+  The final block number of a frozen chain, or `nil` for chains that are
+  still producing blocks (or have not declared `Chain.final_block_number/0`).
+  """
+  def final_block_number(chain) do
+    impl = chainimpl(chain)
+
+    cond do
+      not Code.ensure_loaded?(impl) -> nil
+      not function_exported?(impl, :final_block_number, 0) -> nil
+      true -> impl.final_block_number()
+    end
+  end
+
   @doc false
   def execution_reverted_rpc_error do
     %{"code" => -32000, "message" => "execution reverted"}

--- a/lib/remote_chain/ws_conn.ex
+++ b/lib/remote_chain/ws_conn.ex
@@ -48,16 +48,25 @@ defmodule RemoteChain.WSConn do
   overrides the multiplier — used by `NodeProxy` for its eviction pass (two
   ping cycles, `@stale_eviction_intervals`).
 
+  Frozen chains (see `RemoteChain.frozen?/1`) never satisfy this predicate:
+  the chain is not producing blocks, so `lastblock_at` stays at connect
+  time and would otherwise trigger constant evictions of healthy
+  connections. Provider health is still enforced by TCP/WS disconnects
+  and the subscription handshake (`handle_info(:ping, ...)`).
+
   This is the single threshold shared by `stale?/2` (pid-based), the
   `:ping` close handler, `NodeProxy`'s consensus and eviction logic, and
   `ChainList.block_current?/2`.
   """
   def stale_at?(lastblock_at, chain, intervals \\ @stale_threshold_intervals) do
-    case lastblock_at do
-      nil ->
+    cond do
+      RemoteChain.frozen?(chain) ->
         false
 
-      %DateTime{} ->
+      is_nil(lastblock_at) ->
+        false
+
+      true ->
         age = DateTime.diff(DateTime.utc_now(), lastblock_at, :second)
         age > chain.expected_block_intervall() * intervals
     end
@@ -276,16 +285,24 @@ defmodule RemoteChain.WSConn do
       raise "No subscription id received, aborting connection with #{ws_url}"
     end
 
-    if stale_at?(state.lastblock_at, chain) do
-      {:message_queue_len, len} = Process.info(self(), :message_queue_len)
+    # Frozen chains: the staleness predicate can never be satisfied, so
+    # skip it. The subscription_id check above still guards against a
+    # WSConn that lost its `eth_subscribe("newHeads")` confirmation.
+    cond do
+      RemoteChain.frozen?(chain) ->
+        {:ok, state}
 
-      Logger.warning(
-        "WSConn #{inspect({self(), len})} block timeout #{chain} (#{ws_url}). Restarting..."
-      )
+      stale_at?(state.lastblock_at, chain) ->
+        {:message_queue_len, len} = Process.info(self(), :message_queue_len)
 
-      {:close, state}
-    else
-      {:ok, state}
+        Logger.warning(
+          "WSConn #{inspect({self(), len})} block timeout #{chain} (#{ws_url}). Restarting..."
+        )
+
+        {:close, state}
+
+      true ->
+        {:ok, state}
     end
   end
 

--- a/test/remote_chain/chain_list_test.exs
+++ b/test/remote_chain/chain_list_test.exs
@@ -181,6 +181,50 @@ defmodule RemoteChain.ChainListTest do
     end
   end
 
+  describe "block_current?/2 for frozen chains" do
+    # Regression: Moonbeam stopped producing blocks at 16_796_699. A
+    # healthy provider's `eth_getBlockByNumber("latest")` returns that
+    # block with an ancient timestamp; the age-based check rejects it,
+    # which causes the endpoint probe to fail on every TTL refresh.
+    test "accepts the final block on a frozen chain regardless of timestamp" do
+      final = RemoteChain.final_block_number(Chains.Moonbeam)
+      ancient = System.os_time(:second) - 365 * 24 * 3600
+
+      assert RemoteChain.ChainList.block_current?(Chains.Moonbeam, %{
+               "number" => "0x" <> Integer.to_string(final, 16),
+               "timestamp" => hex_timestamp(ancient)
+             })
+    end
+
+    test "rejects a block whose number does not match the final block on a frozen chain" do
+      # Provider reports a block newer than the freeze → must be wrong
+      # (or the chain has resumed and the final_block_number is stale).
+      final = RemoteChain.final_block_number(Chains.Moonbeam)
+      wrong = "0x" <> Integer.to_string(final + 1, 16)
+
+      refute RemoteChain.ChainList.block_current?(Chains.Moonbeam, %{
+               "number" => wrong,
+               "timestamp" => hex_timestamp(System.os_time(:second))
+             })
+    end
+
+    test "rejects a frozen-chain block without a decodable number" do
+      refute RemoteChain.ChainList.block_current?(Chains.Moonbeam, %{
+               "timestamp" => hex_timestamp(System.os_time(:second))
+             })
+    end
+
+    test "still applies the timestamp check to non-frozen chains" do
+      # Sanity check: a 24h-old block on Anvil (15s cadence) is rejected.
+      stale = System.os_time(:second) - 24 * 3600
+
+      refute RemoteChain.ChainList.block_current?(Chains.Anvil, %{
+               "number" => "0x1",
+               "timestamp" => hex_timestamp(stale)
+             })
+    end
+  end
+
   describe "timestamp_current?/2" do
     test "accepts blocks within max age, rejects older ones" do
       now = System.os_time(:second)

--- a/test/remote_chain/remote_chain_test.exs
+++ b/test/remote_chain/remote_chain_test.exs
@@ -73,4 +73,36 @@ defmodule RemoteChainTest do
       assert RemoteChain.rpc_endpoints(Chains.Diode) == ["http://local-override.example:3834"]
     end
   end
+
+  describe "frozen?/1" do
+    test "returns true for chains that opt in via frozen?/0 (Moonbeam)" do
+      assert RemoteChain.frozen?(Chains.Moonbeam)
+    end
+
+    test "returns false for chains that do not declare frozen?/0" do
+      refute RemoteChain.frozen?(Chains.Diode)
+      refute RemoteChain.frozen?(Chains.OasisSapphire)
+      refute RemoteChain.frozen?(Chains.Base)
+    end
+
+    test "accepts chain_id and chain prefix dispatch" do
+      assert RemoteChain.frozen?(Chains.Moonbeam.chain_id())
+      assert RemoteChain.frozen?("glmr")
+    end
+  end
+
+  describe "final_block_number/1" do
+    test "returns the chain's declared final block number (Moonbeam)" do
+      assert is_integer(RemoteChain.final_block_number(Chains.Moonbeam))
+
+      assert RemoteChain.final_block_number(Chains.Moonbeam) ==
+               Chains.Moonbeam.final_block_number()
+    end
+
+    test "returns nil for chains that have not declared final_block_number/0" do
+      assert RemoteChain.final_block_number(Chains.Diode) == nil
+      assert RemoteChain.final_block_number(Chains.OasisSapphire) == nil
+      assert RemoteChain.final_block_number(Chains.Base) == nil
+    end
+  end
 end

--- a/test/remote_chain/ws_conn_test.exs
+++ b/test/remote_chain/ws_conn_test.exs
@@ -89,4 +89,40 @@ defmodule RemoteChain.WSConnTest do
       assert WSConn.stale_threshold_intervals() == 10
     end
   end
+
+  describe "stale_at?/3 for frozen chains" do
+    # Regression: Moonbeam stopped producing blocks at 16_796_699. Without a
+    # short-circuit, every WSConn's `lastblock_at` is "ancient" relative to
+    # the staleness window, and the watchdog closes/restarts them
+    # continuously, swamping the NodeProxy mailbox and starving RPCs.
+    test "returns false for a frozen chain regardless of how old lastblock_at is" do
+      ancient = DateTime.utc_now() |> DateTime.add(-365 * 24 * 3600, :second)
+      refute WSConn.stale_at?(ancient, Chains.Moonbeam)
+      refute WSConn.stale_at?(ancient, Chains.Moonbeam, 1)
+    end
+
+    test "returns false for a frozen chain even with intervals=0" do
+      ancient = DateTime.utc_now() |> DateTime.add(-3600, :second)
+      refute WSConn.stale_at?(ancient, Chains.Moonbeam, 0)
+    end
+
+    test "returns false for a frozen chain when lastblock_at is nil" do
+      refute WSConn.stale_at?(nil, Chains.Moonbeam)
+    end
+
+    test "still returns true for non-frozen chains with old lastblock_at" do
+      # Sanity check: the short-circuit only affects frozen chains. A 1-day
+      # old timestamp on Anvil (15s cadence) is still stale.
+      ancient = DateTime.utc_now() |> DateTime.add(-24 * 3600, :second)
+      assert WSConn.stale_at?(ancient, Chains.Anvil)
+    end
+  end
+
+  describe "stale?/2 for frozen chains" do
+    test "returns false for a frozen chain with a never-updated lastblock_at" do
+      ancient = DateTime.utc_now() |> DateTime.add(-3600, :second)
+      {:ok, pid} = WSConnStateStub.start(%WSConn{lastblock_at: ancient})
+      refute WSConn.stale?(pid, Chains.Moonbeam)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Moonbeam has stopped producing blocks at **16,796,699 (0x1004c1b)**. The WSConn staleness watchdog (`@stale_eviction_intervals = 20` block intervals ≈ 120 s) was closing every connection because the chain will never satisfy a `newHeads` callback. The NodeProxy then spawned a replacement pointing at the same healthy provider, which never got a newHeads frame either. The repeated `:DOWN` messages and the respawn churn swamped the Moonbeam NodeProxy mailbox (**>500k pending messages observed live on as1**), which made every `eth_getCode` from `FleetValidation` time out at 25 s and crash the EdgeV2 ticket handler. Error log shows 6,037 `Evicting data-stale WSConn` warnings and 70+ `Timeout` crashes in a 6-minute window, all for `Chains.Moonbeam`.

The other three chains (`Diode`, `Base`, `OasisSapphire`) are unaffected.

## Fix

Make the staleness check opt-in per chain. Only `Chains.Moonbeam` declares the new predicate; the helpers default to `false`/`nil` for every other chain, so existing behaviour is preserved.

- `Chains.Moonbeam.frozen?/0` → `true`; `Chains.Moonbeam.final_block_number/0` → `16_796_699` (held as `@final_block_number` for easy update if the chain resumes).
- `RemoteChain.frozen?/1` and `RemoteChain.final_block_number/1` — opt-in via `Code.ensure_loaded?/1` + `function_exported?/3`.
- `RemoteChain.WSConn.stale_at?/3` short-circuits to `false` for frozen chains. The `:ping` handler still raises if `subscription_id == nil` (real disconnect guard), but skips the staleness raise. The `:ping` timer keeps running so connectivity is still verified.
- `RemoteChain.ChainList.block_current?/2` accepts the final block on a frozen chain regardless of timestamp age, so the 5-minute endpoint re-probe doesn't reject the provider as "stopped advancing".

## Verification

Live on as1 (before the fix):

```
message_queue_len: 504_082   # Moonbeam NodeProxy
message_queue_len: 0         # Diode, Base, Oasis
{open: 14, close: 8, …}      # 14 WSConns stuck in WebSockex.open_loop
```

After deploying this branch, expected:

```
{message_queue_len, ~0}      # Moonbeam drains within a minute
{true, 16796699, …}          # RemoteChain.frozen?/1 and final_block_number/1
```

Reproduction trace (from `error.log`):

```
16:20:02.951 [error] Timeout calling {:global, {RemoteChain.NodeProxy, Chains.Moonbeam}} {:rpc, "eth_getCode", ["0x6000…", "0x1004c1b"]}
  FleetValidation.contract?/2
  → RemoteChain.RPCCache.get_code/3
  → RemoteChain.RPCCache.node_proxy_rpc/4
  → GenServerDbg.call({:global, {RemoteChain.NodeProxy, Chains.Moonbeam}}, …, 25_000)
```

## Tests

- `test/remote_chain/remote_chain_test.exs` — `frozen?/1` and `final_block_number/1` default behaviour + Moonbeam opt-in via chain id and prefix.
- `test/remote_chain/ws_conn_test.exs` — `stale_at?/3` and `stale?/2` short-circuit for frozen chains; non-frozen chains still get evicted at the documented threshold.
- `test/remote_chain/chain_list_test.exs` — `block_current?/2` accepts the final block on a frozen chain regardless of timestamp, rejects wrong numbers and missing-number blocks; non-frozen chains still use the timestamp check.

```
$ DIODE_MINIMAL_TEST=1 mix test --no-start test/remote_chain/ test/chains/
103 passed
```

`mix format`, `mix credo`, and `mix dialyzer` clean.

## Deployment

- `mix release` and push to `as1` per `deployment/fabfile.py`.
- `ssh as1 systemctl restart diode.service`.
- Monitor with:
  ```
  ssh as1 'ELIXIR_ERL_OPTIONS="+fnu" /opt/diode_node/bin/diode_node rpc \
    "IO.inspect({RemoteChain.frozen?(Chains.Moonbeam), \
                RemoteChain.final_block_number(Chains.Moonbeam), \
                :erlang.process_info(:global.whereis_name({RemoteChain.NodeProxy, Chains.Moonbeam}), :message_queue_len)})"'
  ```

## Notes

- The `Moonbeam` `developer_fleet_address` and `additional_endpoints` (HTTP only) are unchanged; the upstream `CHAINS_MOONBEAM_WS` env-var override still wins.
- If Moonbeam ever resumes or hard-forks, update `Chains.Moonbeam.@final_block_number` (or remove the `frozen?/0` declaration) and the staleness watchdog automatically re-enables.
- Long-term follow-ups left out of this PR: add a `pick_connection` health-check that excludes handshake-stuck workers; add backpressure so a saturated mailbox fast-fails new `:rpc` calls instead of silently queuing; cache empty `eth_getCode` results in `RPCCache.get_code/3`.
